### PR TITLE
return 0 from cunit reg setup

### DIFF
--- a/test/cunit/registry.c
+++ b/test/cunit/registry.c
@@ -61,4 +61,5 @@ main(int   argc,
     CU_basic_run_tests();
 
     void CU_cleanup_registry();
+    return 0;
 }


### PR DESCRIPTION
clears up a compile warning
