### PR TITLE
Add riak_server_error to riak_event to return server errors to the caller

### DIFF
--- a/src/include/riak_error.h
+++ b/src/include/riak_error.h
@@ -32,6 +32,7 @@ typedef enum riak_error_enum {
     ERIAK_NO_PING,
     ERIAK_LOGGING,
     ERIAK_UNINITIALIZED,
+    ERIAK_SERVER_ERROR,
     ERIAK_LAST_ERRORNUM
 } riak_error;
 
@@ -45,9 +46,52 @@ static const char* errmsgs[] = {
     "Ping failure error",
     "Logging failure",
     "Uninitialized Value",
+    "An error was returned from the server",
     "SENTINEL FOR LAST ERROR MESSAGE"
 };
 #endif
+
+typedef struct _riak_server_error riak_server_error;
+struct _riak_context;
+struct _riak_binary;
+
+/**
+ * @brief Create a new server error structure
+ * @param ctx Riak Context
+ * @param err Returned Server Eeeror
+ * @param errcode Code returned by the server in the error message
+ * @param errmsg Message returned by the server
+ * @returns Error Code
+ */
+
+riak_error
+riak_server_error_new(struct _riak_context *ctx,
+                      riak_server_error   **err,
+                      riak_uint32_t         errcode,
+                      struct _riak_binary   *errmsg);
+
+/**
+ * @brief Free memory used by a server error
+ * @param cxt Riak Context
+ * @param err Server error to free
+ */
+void
+riak_server_error_free(struct _riak_context *ctx,
+                       riak_server_error   **err);
+
+/**
+ * @brief Return the code associated with an error response from the server
+ * @returns Error Code
+ */
+riak_uint32_t
+riak_server_error_get_errcode(riak_server_error *err);
+
+/**
+ * @brief Return the error message returned by the server
+ * @returns Binary representation of error message
+ */
+struct _riak_binary*
+riak_server_error_get_errmsg(riak_server_error *err);
 
 const char*
 riak_strerror(riak_error err);

--- a/src/include/riak_event.h
+++ b/src/include/riak_event.h
@@ -100,4 +100,12 @@ riak_event_get_fd(riak_event *rev);
 riak_context*
 riak_event_get_context(riak_event *rev);
 
+/**
+ * @brief Get the optional server error
+ * @param rev Riak Event
+ * @returns Error message sent from the server
+ */
+riak_server_error*
+riak_event_get_server_error(riak_event *rev);
+
 #endif

--- a/src/internal/riak_event-internal.h
+++ b/src/internal/riak_event-internal.h
@@ -49,6 +49,8 @@ struct _riak_event {
     struct _riak_pb_message *pb_request;
     struct _riak_pb_message *pb_response;
 
+    riak_server_error       *error;
+
     void                    *response;
 };
 

--- a/src/riak.c
+++ b/src/riak.c
@@ -45,6 +45,11 @@ riak_synchronous_request(riak_event **rev_target,
     // Terminates only on error or timeout
     riak_event_loop(rev->context);
     *response = wrapper.response;
+
+    if (rev->error) {
+        return ERIAK_SERVER_ERROR;
+    }
+
     return ERIAK_OK;
 }
 

--- a/src/riak_event.c
+++ b/src/riak_event.c
@@ -54,6 +54,7 @@ riak_event_new(riak_context          *ctx,
     rev->pb_request = NULL;
     rev->pb_response = NULL;
     rev->response = NULL;
+    rev->error = NULL;
 
     // TODO: Implement retry logic
     rev->fd = riak_just_open_a_socket(ctx, ctx->addrinfo);
@@ -131,5 +132,10 @@ riak_event_get_fd(riak_event *rev) {
 riak_context*
 riak_event_get_context(riak_event *rev) {
     return rev->context;
+}
+
+riak_server_error*
+riak_event_get_server_error(riak_event *rev) {
+    return rev->error;
 }
 

--- a/src/riak_messages.c
+++ b/src/riak_messages.c
@@ -82,6 +82,17 @@ riak_decode_error_response(riak_event           *rev,
     }
     *resp = response;
 
+    riak_error err = riak_server_error_new(ctx,
+                                           &(rev->error),
+                                           response->errcode,
+                                           response->errmsg);
+
+    if (err) {
+        riak_free(ctx, &response);
+        rpb_error_resp__free_unpacked(errresp, ctx->pb_allocator);
+        return err;
+    }
+
     return ERIAK_OK;
 }
 


### PR DESCRIPTION
We should think about how to pass this error back to the synchronous caller, too, to get all of the detail.
