### PR TITLE
Remove zlog and implement a simple, plugable logging framework

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,0 @@
-all:
-	scons -f SConscript
-clean:
-	scons -f SConscript -c

--- a/examples/SConscript
+++ b/examples/SConscript
@@ -6,12 +6,11 @@ env = Environment(
     CPPPATH=['include','../../src/include','../../src/internal','../../build/proto'],
     LIBPATH=['../../build']
     )
-env.ParseConfig("pkg-config --libs libevent libprotobuf-c protobuf zlog")
-env.ParseConfig("pkg-config --cflags libevent libprotobuf-c protobuf zlog")
+env.ParseConfig("pkg-config --libs libevent libprotobuf-c protobuf")
+env.ParseConfig("pkg-config --cflags libevent libprotobuf-c protobuf")
 files = ['example.c', 'riak_command.c']
 
-example = env.Program('riakc_example', files, LIBS=['riak_c_client', 'event_core', 'event_extra', 'zlog', 'pthread', 'protobuf', 'protobuf-c','cunit'])
-Command("./build/zlog.conf", "zlog.conf", Copy("$TARGET", "$SOURCE"))
+example = env.Program('riakc_example', files, LIBS=['riak_c_client', 'event_core', 'event_extra', 'pthread', 'protobuf', 'protobuf-c','cunit'])
 
 conf = Configure(env)
 if not conf.CheckLib('pthread'):
@@ -28,10 +27,6 @@ if not conf.CheckLib('protobuf-c'):
 
 if not conf.CheckLib('libevent'):
   print 'Did not find libevent, exiting!'
-  Exit(1)
-
-if not conf.CheckLib('zlog'):
-  print 'Did not find zlog, exiting!'
   Exit(1)
 
 if not conf.CheckLib('cunit'):

--- a/examples/zlog.conf
+++ b/examples/zlog.conf
@@ -1,5 +1,0 @@
-[formats]
-simple = "%m%n"
-normal = "%d(%F %T) %m%n"
-[rules]
-riakc.*    >stdout; normal

--- a/src/SConscript
+++ b/src/SConscript
@@ -2,14 +2,14 @@ import os
 
 env = Environment(
     ENV = os.environ,
-    CCFLAGS = '-g -Wall -DUSE_DEBUG',
+    CCFLAGS = '-g -Wall -DUSE_DEBUG -D_RIAK_DEBUG',
     # .. Required for proctoc-c full pathname
     CPPPATH=['proto','include','internal','..'],
     LIBPATH=['.'],
     toolpath=['tools'],
     tools=['default', 'protoc'])
-env.ParseConfig("pkg-config --libs libevent libprotobuf-c protobuf zlog")
-env.ParseConfig("pkg-config --cflags libevent libprotobuf-c protobuf zlog")
+env.ParseConfig("pkg-config --libs libevent libprotobuf-c protobuf ")
+env.ParseConfig("pkg-config --cflags libevent libprotobuf-c protobuf")
 
 riak_pb = env.Protoc(
     [],
@@ -42,7 +42,7 @@ riak_yokozuna_pb = env.Protoc(
 lib_files = [riak_pb[0], riak_kv_pb[0], riak_search_pb[0], riak_yokozuna_pb[0], Split('riak.c riak_utils.c riak_binary.c riak_config.c riak_connection.c riak_messages.c riak_log.c riak_error.c riak_network.c riak_object.c riak_bucket_props.c riak_call_backs.c riak_print.c riak_async.c riak_options.c')]
 
 env.Library('riak_c_client', lib_files)
-#env.Program('riak_c_client','main.c', LIBS=['riak_c_client', 'event_core', 'event_extra', 'zlog', 'pthread', 'protobuf', 'protobuf-c'])
+#env.Program('riak_c_client','main.c', LIBS=['riak_c_client', 'event_core', 'event_extra', 'pthread', 'protobuf', 'protobuf-c'])
 
 
 conf = Configure(env)
@@ -65,11 +65,6 @@ if not conf.CheckLib('protobuf-c'):
 if not conf.CheckLib('libevent'):
   print 'Did not find libevent, exiting!'
   Exit(1)
-
-if not conf.CheckLib('zlog'):
-  print 'Did not find zlog, exiting!'
-  Exit(1)
-
 
 env = conf.Finish()
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -2,7 +2,7 @@ import os
 
 env = Environment(
     ENV = os.environ,
-    CCFLAGS = '-g -Wall -DUSE_DEBUG -D_RIAK_DEBUG',
+    CCFLAGS = '-g -Wall -DUSE_DEBUG',
     # .. Required for proctoc-c full pathname
     CPPPATH=['proto','include','internal','..'],
     LIBPATH=['.'],

--- a/src/include/riak.h
+++ b/src/include/riak.h
@@ -35,6 +35,7 @@
 #include <event2/util.h>
 #include <event2/event.h>
 #include "riak_types.h"
+#include "riak_log_config.h"
 #include "riak_error.h"
 #include "riak_config.h"
 #include "riak_binary.h"

--- a/src/include/riak_config.h
+++ b/src/include/riak_config.h
@@ -36,7 +36,7 @@ typedef struct _riak_config riak_config;
 
 /**
  * @brief Construct a Riak Configuration
- * @param config Spanking new `riak_config` struct
+ * @param cfg Spanking new `riak_config` struct
  * @param alloc Memory allocator function (optional)
  * @param realloc Memory re-allocation function (optional)
  * @param freeme Memory releasing function (optional)
@@ -45,25 +45,25 @@ typedef struct _riak_config riak_config;
  * @return Error code
  */
 riak_error
-riak_config_new(riak_config    **config,
-                 riak_alloc_fn     alloc,
-                 riak_realloc_fn   realloc,
-                 riak_free_fn      freeme,
-                 riak_pb_alloc_fn  pb_alloc,
-                 riak_pb_free_fn   pb_free);
+riak_config_new(riak_config     **cfg,
+                riak_alloc_fn     alloc,
+                riak_realloc_fn   realloc,
+                riak_free_fn      freeme,
+                riak_pb_alloc_fn  pb_alloc,
+                riak_pb_free_fn   pb_free);
 // By default use system's built-in memory management utilities (malloc/free)
 #define riak_config_new_default(C) riak_config_new((C),NULL,NULL,NULL,NULL,NULL)
 
 /**
  * @brief Construct a Riak Configuration
- * @param config Existing Riak Configuration
+ * @param cfg Existing Riak Configuration
  * @param resolver IP Address resolving function
  * @param hostname Name of Riak server
  * @param portnum Riak PBC port number
  * @return Error code
  */
 riak_error
-riak_config_add_connection(riak_config      *config,
+riak_config_add_connection(riak_config        *cfg,
                             riak_addr_resolver resolver,
                             const char        *hostname,
                             const char        *portnum);
@@ -71,14 +71,20 @@ riak_config_add_connection(riak_config      *config,
 #define riak_config_add_default_connection(C,H,P) riak_config_add_connection((C),NULL,(H),(P))
 
 /**
- * @brief Construct a Riak Configuration
- * @param config Spanking new `riak_config` struct
- * @param logging_category logging prefix (optional)
+ * @brief Add logging functions
+ * @param config Riak Configuration
+ * @param log_data Pointer passed to all logging functions
+ * @param log_fn Main logging function
+ * @param log_init Function called once at setup
+ * @param log_cleanup Function called at program termination
  * @return Error code
  */
 riak_error
-riak_config_add_logging(riak_config *config,
-                         const char   *logging_category);
+riak_config_set_logging(riak_config        *cfg,
+                        void*               log_data,
+                        riak_log_fn         log_fn,
+                        riak_log_init_fn    log_init,
+                        riak_log_cleanup_fn log_cleanup);
 
 
 /**

--- a/src/include/riak_connection.h
+++ b/src/include/riak_connection.h
@@ -38,10 +38,10 @@ typedef void (*riak_response_callback)(void *response, void *ptr);
  */
 riak_error
 riak_connection_new(riak_config          *cfg,
-               riak_connection             **cxn,
-               riak_response_callback response_cb,
-               riak_response_callback error_cb,
-               void                  *cb_data);
+                    riak_connection             **cxn,
+                    riak_response_callback response_cb,
+                    riak_response_callback error_cb,
+                    void                  *cb_data);
 
 /**
  * @brief Set the event's callback data
@@ -50,7 +50,7 @@ riak_connection_new(riak_config          *cfg,
  */
 void
 riak_connection_set_cb_data(riak_connection         *cxn,
-                       void               *cb_data);
+                            void               *cb_data);
 
 /**
  * @brief Set the event's response callback
@@ -59,7 +59,7 @@ riak_connection_set_cb_data(riak_connection         *cxn,
  */
 void
 riak_connection_set_response_cb(riak_connection             *cxn,
-                           riak_response_callback  cb);
+                                riak_response_callback  cb);
 
 /**
  * @brief Set the event's error callback

--- a/src/include/riak_log.h
+++ b/src/include/riak_log.h
@@ -23,19 +23,6 @@
 #ifndef RIAK_LOG_H_
 #define RIAK_LOG_H_
 
-#include <stdarg.h>
-
-// Pulled from zlog.h but correspond to log levels from syslog(3)
-typedef enum {
-    /** fatal */    RIAK_LOG_FATAL,
-    /** error */    RIAK_LOG_ERROR,
-    /** warn */     RIAK_LOG_WARN,
-    /** notice */   RIAK_LOG_NOTICE,
-    /** info */     RIAK_LOG_INFO,
-    /** debug */    RIAK_LOG_DEBUG,
-    /** unknown */  RIAK_LOG_UNKNOWN
-} riak_log_level_t;
-
 /**
  * @brief Add a record to the Riak log
  * @param cfg Riak Configuration
@@ -50,18 +37,24 @@ typedef enum {
  */
 
 void
-riak_log_internal(riak_config    *cfg,
-                  riak_log_level_t level,
-                  const char      *file,
-                  size_t           filelen,
-                  const char      *func,
-                  size_t           funclen,
-                  long             line,
-                  const char      *format,
+riak_log_internal(riak_config         *cfg,
+                  riak_log_level_t     level,
+                  const char          *file,
+                  riak_size_t          filelen,
+                  const char          *func,
+                  riak_size_t          funclen,
+                  riak_uint32_t        line,
+                  const char          *format,
                   ...);
 
-#define riak_log_fatal(cxn,format, ...) \
-        riak_log_internal(riak_connection_get_config(cxn), RIAK_LOG_FATAL, __FILE__, sizeof(__FILE__)-1, \
+#define riak_log_emergency(cxn,format, ...) \
+        riak_log_internal(riak_connection_get_config(cxn), RIAK_LOG_EMERG, __FILE__, sizeof(__FILE__)-1, \
+        __func__, sizeof(__func__)-1, __LINE__, ("[%d] " format), riak_connection_get_fd(cxn), __VA_ARGS__)
+#define riak_log_alert(cxn,format, ...) \
+        riak_log_internal(riak_connection_get_config(cxn), RIAK_LOG_ALERT, __FILE__, sizeof(__FILE__)-1, \
+        __func__, sizeof(__func__)-1, __LINE__, ("[%d] " format), riak_connection_get_fd(cxn), __VA_ARGS__)
+#define riak_log_critical(cxn,format, ...) \
+        riak_log_internal(riak_connection_get_config(cxn), RIAK_LOG_CRITICAL, __FILE__, sizeof(__FILE__)-1, \
         __func__, sizeof(__func__)-1, __LINE__, ("[%d] " format), riak_connection_get_fd(cxn), __VA_ARGS__)
 #define riak_log_error(cxn,format, ...) \
         riak_log_internal(riak_connection_get_config(cxn), RIAK_LOG_ERROR, __FILE__, sizeof(__FILE__)-1, \
@@ -80,8 +73,14 @@ riak_log_internal(riak_config    *cfg,
 #define riak_log_debug(cxn,format, ...) // No-Op
 #endif
 
-#define riak_log_fatal_config(cfg,format, ...) \
-        riak_log_internal((cfg), RIAK_LOG_FATAL, __FILE__, sizeof(__FILE__)-1, \
+#define riak_log_emergency_config(cfg,format, ...) \
+        riak_log_internal((cfg), RIAK_LOG_EMERG, __FILE__, sizeof(__FILE__)-1, \
+        __func__, sizeof(__func__)-1, __LINE__, (format), __VA_ARGS__)
+#define riak_log_alert_config(cfg,format, ...) \
+        riak_log_internal((cfg), RIAK_LOG_ALERT, __FILE__, sizeof(__FILE__)-1, \
+        __func__, sizeof(__func__)-1, __LINE__, (format), __VA_ARGS__)
+#define riak_log_critical_config(cfg,format, ...) \
+        riak_log_internal((cfg), RIAK_LOG_CRITICAL, __FILE__, sizeof(__FILE__)-1, \
         __func__, sizeof(__func__)-1, __LINE__, (format), __VA_ARGS__)
 #define riak_log_error_config(cxn,format, ...) \
         riak_log_internal((cfg), RIAK_LOG_ERROR, __FILE__, sizeof(__FILE__)-1, \

--- a/src/include/riak_log_config.h
+++ b/src/include/riak_log_config.h
@@ -1,0 +1,88 @@
+/*********************************************************************
+ *
+ * riak_log_config.h: Riak C Logging Configuration
+ *
+ * Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+ *
+ * This file is provided to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *********************************************************************/
+
+#ifndef RIAK_LOG_CONFIG_H_
+#define RIAK_LOG_H_CONFIG_H_
+
+#include <stdarg.h>
+
+// Levels correspond to RFC 5424
+// http://en.wikipedia.org/wiki/Syslog#Severity_levels
+typedef enum {
+    /** emergency */     RIAK_LOG_EMERG,
+    /** alert */         RIAK_LOG_ALERT,
+    /** critical */      RIAK_LOG_CRITICAL,
+    /** error */         RIAK_LOG_ERROR,
+    /** warning */       RIAK_LOG_WARN,
+    /** notice */        RIAK_LOG_NOTICE,
+    /** informational */ RIAK_LOG_INFO,
+    /** debug */         RIAK_LOG_DEBUG,
+    /** unknown */       RIAK_LOG_UNKNOWN
+} riak_log_level_t;
+
+#ifdef _RIAK_LOG_DESCRIPTION
+const char* riak_log_description[] = {
+    "EMER",
+    "ALRT",
+    "CRIT",
+    "ERRO",
+    "WARN",
+    "NOTE",
+    "INFO",
+    "DEBG",
+    "UNKN"
+};
+#else
+extern const char *riak_log_description[];
+#endif
+static inline const char*
+riak_log_level_description(riak_log_level_t level) {
+    if (level < RIAK_LOG_EMERG || level > RIAK_LOG_UNKNOWN) level = RIAK_LOG_UNKNOWN;
+    return riak_log_description[level];
+}
+
+typedef riak_int32_t (*riak_log_init_fn)(void *ptr);
+typedef void (*riak_log_cleanup_fn)(void *ptr);
+
+/**
+ * @brief Definition of logging function
+ * @param ptr User-defined logging data
+ * @param level Syslog-like logging message priority
+ * @param file Name of file where message is issued
+ * @param filelen Length of `file` field
+ * @param func Name of function where message is issued
+ * @param funclen Length of `func` field
+ * @param line Line number where message is issued
+ * @param format printf-like format string
+ * @param args List of arguments for `format`
+ */
+typedef void (*riak_log_fn)(void            *ptr,
+                            riak_log_level_t level,
+                            const char      *file,
+                            riak_size_t      filelen,
+                            const char      *func,
+                            riak_size_t      funclen,
+                            riak_uint32_t    line,
+                            const char      *format,
+                            va_list          args);
+
+#endif

--- a/src/internal/riak_config-internal.h
+++ b/src/internal/riak_config-internal.h
@@ -23,9 +23,6 @@
 #ifndef RIAK_CONTEXT_INTERNAL_H_
 #define RIAK_CONTEXT_INTERNAL_H_
 
-// TODO: one day make this configurable?
-// FYI, zlog does not support dots or hyphens in the category
-#define RIAK_LOGGING_DEFAULT_CATEGORY   "riakc"
 #define RIAK_LOGGING_MAX_LEN            256
 #define RIAK_HOST_MAX_LEN               256
 
@@ -34,8 +31,15 @@ struct _riak_config {
     riak_realloc_fn     realloc_fn;
     riak_free_fn        free_fn;
     ProtobufCAllocator *pb_allocator;
-    char                logging_category[RIAK_LOGGING_MAX_LEN];
-    riak_connection_base    *base; // Is this the right location? One per thread, so probably
+
+    // LOGGING
+    void*               log_data;
+    riak_log_fn         log_fn;
+    riak_log_init_fn    log_init_fn;
+    riak_log_cleanup_fn log_cleanup_fn;
+
+    // EVENT LIBRARY
+    riak_connection_base *base; // Is this the right location? One per thread, so probably
     char                hostname[RIAK_HOST_MAX_LEN];
     char                portnum[RIAK_HOST_MAX_LEN]; // Keep as a string for debugging
     riak_addrinfo      *addrinfo;

--- a/src/riak.c
+++ b/src/riak.c
@@ -38,7 +38,7 @@ riak_synchronous_request(riak_connection **cxn_target,
 
     riak_error err = riak_send_req(cxn, cxn->pb_request);
     if (err) {
-        riak_log_fatal(cxn, "Could not send request", NULL);
+        riak_log_critical(cxn, "Could not send request", NULL);
         return err;
     }
 

--- a/src/riak_call_backs.c
+++ b/src/riak_call_backs.c
@@ -186,8 +186,8 @@ riak_connection_callback(riak_bufferevent *bev,
                 riak_log_error(cxn, "DNS error: %s", evutil_gai_strerror(err));
          }
 #ifdef _RIAK_DEBUG
-         struct evbuffer *ev_read  = buffecxnent_get_input(bev);
-         struct evbuffer *ev_write = buffecxnent_get_output(bev);
+         struct evbuffer *ev_read  = bufferevent_get_input(bev);
+         struct evbuffer *ev_write = bufferevent_get_output(bev);
 #endif
          riak_log_debug(cxn, "Closing because of %s [read event=%p, write event=%p]",
                  reason, (void*)ev_read, (void*)ev_write);
@@ -208,9 +208,9 @@ riak_write_callback(riak_bufferevent *bev,
                     void             *ptr)
 {
 #ifdef _RIAK_DEBUG
-    riak_connection   **cxn_target = (riak_connection**)ptr;
-    riak_connection    *cxn = *cxn_target;
-    struct evbuffer *buf = buffecxnent_get_output(bev);
+    riak_connection **cxn_target = (riak_connection**)ptr;
+    riak_connection  *cxn = *cxn_target;
+    struct evbuffer  *buf = bufferevent_get_output(bev);
     riak_log_debug(cxn, "Ready for write with event %p.\n", (void*)buf);
 #endif
 }

--- a/src/riak_connection.c
+++ b/src/riak_connection.c
@@ -37,7 +37,7 @@ riak_connection_new(riak_config      *cfg,
 
     riak_connection *cxn = (riak_connection*)(cfg->malloc_fn)(sizeof(riak_connection));
     if (cxn == NULL) {
-        riak_log_fatal_config(cfg, "%s", "Could not allocate a riak_connection");
+        riak_log_critical_config(cfg, "%s", "Could not allocate a riak_connection");
         return ERIAK_OUT_OF_MEMORY;
     }
     *cxn_target = cxn;
@@ -59,19 +59,19 @@ riak_connection_new(riak_config      *cfg,
     // TODO: Implement retry logic
     cxn->fd = riak_just_open_a_socket(cfg, cfg->addrinfo);
     if (cxn->fd < 0) {
-        riak_log_fatal_config(cfg, "%s", "Could not just open a socket");
+        riak_log_critical_config(cfg, "%s", "Could not just open a socket");
         return ERIAK_LOGGING;
     }
 
     // cxn->bevent = buffecxnent_socket_new(base, sock, BEV_OPT_CLOSE_ON_FREE|BEV_OPT_DEFER_CALLBACKS|BEV_OPT_THREADSAFE);
     cxn->bevent = bufferevent_socket_new(cxn->base, cxn->fd, BEV_OPT_CLOSE_ON_FREE|BEV_OPT_DEFER_CALLBACKS);
     if (cxn->bevent == NULL) {
-        riak_log_fatal_config(cfg, "Could not create bufferevent [fd %d]", cxn->fd);
+        riak_log_critical_config(cfg, "Could not create bufferevent [fd %d]", cxn->fd);
         return ERIAK_OUT_OF_MEMORY;
     }
     int enabled = bufferevent_enable(cxn->bevent, EV_READ|EV_WRITE);
     if (enabled != 0) {
-        riak_log_fatal_config(cfg, "Could not enable bufferevent [fd %d]", cxn->fd);
+        riak_log_critical_config(cfg, "Could not enable bufferevent [fd %d]", cxn->fd);
         return ERIAK_EVENT;
     }
 

--- a/src/riak_network.c
+++ b/src/riak_network.c
@@ -45,7 +45,7 @@ riak_resolve_address(riak_config       *cfg,
     // Use nice, platform agnostic DNS lookup and return an array of results
     int err = resolver(host, portnum, &addrhints, addrinfo);
     if (err != 0) {
-        riak_log_fatal_config(cfg, "Error while resolving '%s:%s': %s",
+        riak_log_critical_config(cfg, "Error while resolving '%s:%s': %s",
                  host, portnum, evutil_gai_strerror(err));
         return ERIAK_DNS_RESOLUTION;
     }
@@ -85,7 +85,7 @@ riak_just_open_a_socket(riak_config   *cfg,
                                 addrinfo->ai_socktype,
                                 addrinfo->ai_protocol);
     if (sock < 0) {
-        riak_log_fatal_config(cfg, "%s", "Could not just open a socket");
+        riak_log_critical_config(cfg, "%s", "Could not just open a socket");
         return -1;
     }
     int err = connect(sock, addrinfo->ai_addr, addrinfo->ai_addrlen);
@@ -97,7 +97,7 @@ riak_just_open_a_socket(riak_config   *cfg,
             riak_uint16_t port;
             riak_print_host(addrinfo, ip, sizeof(ip), &port);
             EVUTIL_CLOSESOCKET(sock);
-            riak_log_fatal_config(cfg, "Could not connect a socket to host %s:%d [%s]\n", ip, port, strerror(errno));
+            riak_log_critical_config(cfg, "Could not connect a socket to host %s:%d [%s]\n", ip, port, strerror(errno));
             return -1;
         }
     }

--- a/src/riak_utils.c
+++ b/src/riak_utils.c
@@ -111,13 +111,13 @@ riak_send_req(riak_connection *cxn,
     char *pos = buffer;
     riak_int32_t wrote = 0;
     int i;
-    for(i = 0; i < buflen; i++) {
+    for(i = 0; buflen > 0 && i < len; i++) {
         wrote = snprintf(pos, buflen, "%02x", msgbuf[i]);
         pos += wrote;
         buflen -= wrote;
     }
     fprintf(stdout, "\n");
-    for(i = 0; i < buflen; i++) {
+    for(i = 0; buflen > 0 && i < len; i++) {
         char c = '.';
         if (msgbuf[i] > 31 && msgbuf[i] < 128) {
             c = msgbuf[i];

--- a/test/cunit/SConscript
+++ b/test/cunit/SConscript
@@ -6,11 +6,11 @@ env = Environment(
     CPPPATH=['include','../../src/include','../../src/internal','../../build/proto'],
     LIBPATH=['../../build']
     )
-env.ParseConfig("pkg-config --libs libevent libprotobuf-c protobuf zlog")
-env.ParseConfig("pkg-config --cflags libevent libprotobuf-c protobuf zlog")
+env.ParseConfig("pkg-config --libs libevent libprotobuf-c protobuf")
+env.ParseConfig("pkg-config --cflags libevent libprotobuf-c protobuf")
 files = ['registry.c','test_binary.c','test_config.c']
 
-riak_c_cunit = env.Program('riak_c_cunit', files, LIBS=['riak_c_client', 'event_core', 'event_extra', 'zlog', 'pthread', 'protobuf', 'protobuf-c','cunit'])
+riak_c_cunit = env.Program('riak_c_cunit', files, LIBS=['riak_c_client', 'event_core', 'event_extra', 'pthread', 'protobuf', 'protobuf-c','cunit'])
 Depends(riak_c_cunit, '../../build/libriak_c_client.a')
 
 conf = Configure(env)
@@ -28,10 +28,6 @@ if not conf.CheckLib('protobuf-c'):
 
 if not conf.CheckLib('libevent'):
   print 'Did not find libevent, exiting!'
-  Exit(1)
-
-if not conf.CheckLib('zlog'):
-  print 'Did not find zlog, exiting!'
   Exit(1)
 
 if not conf.CheckLib('cunit'):

--- a/test/cunit/test_config.c
+++ b/test/cunit/test_config.c
@@ -96,14 +96,40 @@ test_config_with_connection() {
     CU_PASS("test_build_binary passed")
 }
 
+typedef struct {
+    riak_boolean_t init;
+    riak_boolean_t log;
+    riak_boolean_t cleanup;
+} test_log_data;
+
+riak_int32_t
+test_log_init(void *ptr) {
+    return 0;
+}
+
+void
+test_log_cleanup(void *ptr) {
+}
+
+void
+test_log_logger(void            *ptr,
+                riak_log_level_t level,
+                const char      *file,
+                riak_size_t      filelen,
+                const char      *func,
+                riak_size_t      funclen,
+                riak_uint32_t    line,
+                const char      *format,
+                va_list          args) {
+}
+
 void
 test_config_with_logging() {
     riak_config *cfg;
     riak_error err = riak_config_new_default(&cfg);
     CU_ASSERT_FATAL(err == ERIAK_OK)
-    err = riak_config_add_logging(cfg, "test");
+    err = riak_config_set_logging(cfg, (void*)cfg, test_log_logger, test_log_init, test_log_cleanup);
     CU_ASSERT_FATAL(err == ERIAK_OK)
-    CU_ASSERT(strcmp(cfg->logging_category, "test") == 0)
     riak_config_free(&cfg);
     CU_PASS("test_build_binary passed")
 }

--- a/zlog.conf
+++ b/zlog.conf
@@ -1,5 +1,0 @@
-[formats]
-simple = "%m%n"
-normal = "%d(%F %T) %m%n"
-[rules]
-riakc.*    >stdout; normal


### PR DESCRIPTION
I'm happy to make default logging more robust, but I figure we can always add that as necessary.  This addresses https://github.com/basho/riak-c-client/issues/21
