### PR TITLE
Fix Issue #15: Cache bucket/key in riak_operation

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -66,7 +66,6 @@ example_log(void            *ptr,
     ltime = time(NULL);
     localtime_r(&ltime, &result);
     strftime(stime, sizeof(stime), "%F %X %Z", &result);
-
     fprintf(datum->fp, "%s %s ", stime, riak_log_level_description(level));
     vfprintf(datum->fp, format, args);
     fprintf(datum->fp, "\n");

--- a/src/include/riak_binary.h
+++ b/src/include/riak_binary.h
@@ -40,14 +40,12 @@ riak_binary_new(riak_config *cfg,
 
 /**
  * @brief Allocate a new `riak_binary` struct
- * @param len Length of binary in bytes
- * @param data Pointer to binary data (shallow copy)
+ * @param bin Original Riak Binary
  * @returns pointer to newly created `riak_binary` struct
  */
 riak_binary*
 riak_binary_deep_new(riak_config *cfg,
-                     riak_size_t   len,
-                     riak_uint8_t *data);
+                     riak_binary *bin);
 
 /**
  * @brief Allocate a new riak_binary and populate from data pointer

--- a/src/include/riak_operation.h
+++ b/src/include/riak_operation.h
@@ -101,4 +101,38 @@ riak_operation_get_connection(riak_operation *rop);
 riak_server_error*
 riak_operation_get_server_error(riak_operation *rop);
 
+/**
+ * @brief Set the bucket on the current operation
+ * @param rop Riak Operation
+ * @param bucket Name of bucket in Riak
+ */
+void
+riak_operation_set_bucket(riak_operation *rop,
+                          riak_binary    *bucket);
+
+/**
+ * @brief Set the bucket on the current operation
+ * @param rop Riak Operation
+ * @param key Name of key in Riak bucket
+ */
+void
+riak_operation_set_key(riak_operation *rop,
+                       riak_binary    *key);
+
+/**
+ * @brief Gets the bucket on the current operation
+ * @param rop Riak Operation
+ * @returns Name of bucket in Riak
+ */
+riak_binary*
+riak_operation_get_bucket(riak_operation *rop);
+
+/**
+ * @brief Gets the key on the current operation
+ * @param rop Riak Operation
+ * @returns Name of key in Riak bucket
+ */
+riak_binary*
+riak_operation_get_key(riak_operation *rop);
+
 #endif

--- a/src/internal/riak_operation-internal.h
+++ b/src/internal/riak_operation-internal.h
@@ -49,6 +49,12 @@ struct _riak_operation {
     riak_server_error       *error;
 
     void                    *response;
+
+    // Cache of request data
+    struct {
+        riak_binary *bucket;
+        riak_binary *key;
+    } request;
 };
 
 /**

--- a/src/riak_binary.c
+++ b/src/riak_binary.c
@@ -25,13 +25,12 @@
 #include "riak_binary-internal.h"
 #include "riak_messages-internal.h"
 #include "riak_utils-internal.h"
-#include "riak_config-internal.h"
 
 riak_binary*
 riak_binary_new(riak_config  *cfg,
                 riak_size_t   len,
                 riak_uint8_t *data) {
-    riak_binary *b = (riak_binary*)(cfg->malloc_fn)(sizeof(riak_binary));
+    riak_binary *b = (riak_binary*)riak_config_allocate(cfg, sizeof(riak_binary));
     if (b == NULL) return NULL;
     b->len  = len;
     b->data = data;
@@ -41,13 +40,12 @@ riak_binary_new(riak_config  *cfg,
 
 riak_binary*
 riak_binary_deep_new(riak_config *cfg,
-                    riak_size_t   len,
-                    riak_uint8_t *data) {
+                     riak_binary *bin) {
 
-    riak_binary *b = riak_binary_new(cfg, len, data);
+    riak_binary *b = riak_binary_new(cfg, bin->len, bin->data);
     if (b) {
-        b->data = (riak_uint8_t*)(cfg->malloc_fn)(len);
-        memcpy((void*)b->data, (void*)data, len);
+        b->data = (riak_uint8_t*)riak_config_allocate(cfg, bin->len);
+        memcpy((void*)b->data, (void*)bin->data, bin->len);
     }
     return b;
 }
@@ -116,7 +114,7 @@ riak_binary_deep_copy(riak_config *cfg,
                       riak_binary *to,
                       riak_binary *from) {
     to->len  = from->len;
-    to->data = (riak_uint8_t*)(cfg->malloc_fn)(from->len);
+    to->data = (riak_uint8_t*)riak_config_allocate(cfg, from->len);
     if (to->data == NULL) return ERIAK_OUT_OF_MEMORY;
     memcpy((void*)to->data, (void*)from->data, from->len);
     return ERIAK_OK;
@@ -134,7 +132,7 @@ riak_binary_to_pb_deep_copy(riak_config         *cfg,
                             ProtobufCBinaryData *to,
                             riak_binary         *from) {
     to->len  = from->len;
-    to->data = (riak_uint8_t*)(cfg->malloc_fn)(from->len);
+    to->data = (riak_uint8_t*)riak_config_allocate(cfg, from->len);
     if (to->data == NULL) return ERIAK_OUT_OF_MEMORY;
     memcpy((void*)to->data, (void*)from->data, from->len);
     return ERIAK_OK;
@@ -152,7 +150,7 @@ riak_binary_from_pb_deep_copy(riak_config         *cfg,
                               riak_binary         *to,
                               ProtobufCBinaryData *from) {
     to->len  = from->len;
-    to->data = (riak_uint8_t*)(cfg->malloc_fn)(from->len);
+    to->data = (riak_uint8_t*)riak_config_allocate(cfg, from->len);
     if (to->data == NULL) return ERIAK_OUT_OF_MEMORY;
     memcpy((void*)to->data, (void*)from->data, from->len);
     return ERIAK_OK;
@@ -208,7 +206,7 @@ riak_binary_from_string_deep_copy(riak_config *cfg,
                                   const char  *from) {
 
     to->len = strlen(from);
-    to->data = (riak_uint8_t*)(cfg->malloc_fn)(to->len);
+    to->data = (riak_uint8_t*)riak_config_allocate(cfg, to->len);
     if (to->data == NULL) return ERIAK_OUT_OF_MEMORY;
     memcpy((void*)to->data, (void*)from, to->len);
     return ERIAK_OK;

--- a/src/riak_error.c
+++ b/src/riak_error.c
@@ -42,9 +42,7 @@ riak_server_error_new(struct _riak_config  *cfg,
     }
     *err = error;
     error->errcode = errcode;
-    error->errmsg = riak_binary_deep_new(cfg,
-                                         riak_binary_len(errmsg),
-                                         riak_binary_data(errmsg));
+    error->errmsg = riak_binary_deep_new(cfg, errmsg);
 
     if (error->errmsg == NULL) {
         riak_free(cfg, err);

--- a/src/riak_messages.c
+++ b/src/riak_messages.c
@@ -241,6 +241,8 @@ riak_encode_get_request(riak_operation  *rop,
     riak_config *cfg = riak_operation_get_config(rop);
     RpbGetReq getmsg = RPB_GET_REQ__INIT;
 
+    riak_operation_set_bucket(rop, bucket);
+    riak_operation_set_key(rop, key);
     riak_binary_to_pb_copy(&getmsg.bucket, bucket);
     riak_binary_to_pb_copy(&getmsg.key, key);
 
@@ -333,6 +335,9 @@ riak_decode_get_response(riak_operation     *rop,
                 riak_free(cfg, &response);
                 return err;
             }
+            response->content[i]->bucket  = riak_binary_deep_new(cfg, riak_operation_get_bucket(rop));
+            response->content[i]->key     = riak_binary_deep_new(cfg, riak_operation_get_key(rop));
+            response->content[i]->has_key = RIAK_TRUE;
         }
     }
     *resp = response;

--- a/src/riak_operation.c
+++ b/src/riak_operation.c
@@ -94,3 +94,29 @@ riak_operation_set_response_decoder(riak_operation       *rop,
     rop->decoder = decoder;
 }
 
+void
+riak_operation_set_bucket(riak_operation *rop,
+                          riak_binary    *bucket) {
+    riak_connection *cxn = riak_operation_get_connection(rop);
+    riak_config     *cfg = riak_connection_get_config(cxn);
+    rop->request.bucket = riak_binary_deep_new(cfg, bucket);
+}
+
+void
+riak_operation_set_key(riak_operation *rop,
+                       riak_binary    *key) {
+    riak_connection *cxn = riak_operation_get_connection(rop);
+    riak_config     *cfg = riak_connection_get_config(cxn);
+    rop->request.key = riak_binary_deep_new(cfg, key);
+}
+
+riak_binary*
+riak_operation_get_bucket(riak_operation *rop) {
+    return rop->request.bucket;
+}
+
+riak_binary*
+riak_operation_get_key(riak_operation *rop) {
+    return rop->request.key;
+}
+

--- a/src/riak_operation.c
+++ b/src/riak_operation.c
@@ -53,6 +53,8 @@ riak_operation_free(riak_operation **rop_target) {
     if (rop->pb_request) {
         riak_pb_message_free(cfg, &(rop->pb_request));
     }
+    riak_free(cfg, &(rop->request.bucket));
+    riak_free(cfg, &(rop->request.key));
     riak_free(cfg, rop_target);
 }
 


### PR DESCRIPTION
Since these fields are not returned in the request, the only way to return them in the riak_object is to cache them in the GET request.
