### PR TITLE
Simplify the riak_binary

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -134,11 +134,11 @@ main(int   argc,
     int it;
 
     // create some sample binary values to use
-    riak_binary *bucket_bin   = riak_binary_new_from_string(cfg, args.bucket); // Not copied
-    riak_binary *key_bin      = riak_binary_new_from_string(cfg, args.key);   // Not copied
-    riak_binary *value_bin    = riak_binary_new_from_string(cfg, args.value); // Not copied
-    riak_binary *index_bin    = riak_binary_new_from_string(cfg, args.index); // Not copied
-    riak_binary *content_type = riak_binary_new_from_string(cfg, "application/json");
+    riak_binary *bucket_bin   = riak_binary_copy_from_string(cfg, args.bucket); // Not copied
+    riak_binary *key_bin      = riak_binary_copy_from_string(cfg, args.key);   // Not copied
+    riak_binary *value_bin    = riak_binary_copy_from_string(cfg, args.value); // Not copied
+    riak_binary *index_bin    = riak_binary_copy_from_string(cfg, args.index); // Not copied
+    riak_binary *content_type = riak_binary_copy_from_string(cfg, "application/json");
 
     // check for memory allocation problems
     if (bucket_bin == NULL ||
@@ -237,11 +237,11 @@ main(int   argc,
                 riak_log_critical(cxn, "%s","Could not allocate a Riak Object");
                 return 1;
             }
-            riak_object_set_bucket(obj, riak_binary_new_from_string(cfg, args.bucket)); // Not copied
+            riak_object_set_bucket(obj, riak_binary_copy_from_string(cfg, args.bucket)); // Not copied
             if (args.has_key) {
-                riak_object_set_key(obj, riak_binary_new_from_string(cfg, args.key)); // Not copied
+                riak_object_set_key(obj, riak_binary_copy_from_string(cfg, args.key)); // Not copied
             }
-            riak_object_set_value(obj, riak_binary_new_from_string(cfg, args.value)); // Not copied
+            riak_object_set_value(obj, riak_binary_copy_from_string(cfg, args.value)); // Not copied
             if (riak_object_get_bucket(obj) == NULL ||
                 riak_object_get_value(obj) == NULL) {
                 fprintf(stderr, "Could not allocate bucket/value\n");
@@ -510,6 +510,8 @@ main(int   argc,
     riak_free(cfg, &bucket_bin);
     riak_free(cfg, &key_bin);
     riak_free(cfg, &value_bin);
+    riak_free(cfg, &index_bin);
+    riak_free(cfg, &content_type);
     riak_config_free(&cfg);
 
     return 0;

--- a/src/include/riak_binary.h
+++ b/src/include/riak_binary.h
@@ -27,7 +27,7 @@
 typedef struct _riak_binary riak_binary;
 
 /**
- * @brief Allocate a new `riak_binary` struct (shallow copy)
+ * @brief Allocate a new `riak_binary` struct
  * @param cfg Riak Configuration
  * @param len Length of binary in bytes
  * @param data Pointer to binary data
@@ -39,6 +39,18 @@ riak_binary_new(riak_config  *cfg,
                 riak_uint8_t *data);
 
 /**
+ * @brief Allocate a new `riak_binary` struct (shallow copy)
+ * @param cfg Riak Configuration
+ * @param len Length of binary in bytes
+ * @param data Pointer to binary data
+ * @returns pointer to newly created `riak_binary` struct
+ */
+riak_binary*
+riak_binary_new_shallow(riak_config  *cfg,
+                        riak_size_t   len,
+                        riak_uint8_t *data);
+
+/**
  * @brief Allocate a new `riak_binary` struct
  * @param cfg Riak Configuration
  * @param bin Original Riak Binary
@@ -47,6 +59,16 @@ riak_binary_new(riak_config  *cfg,
 riak_binary*
 riak_binary_copy(riak_config *cfg,
                  riak_binary *bin);
+
+/**
+ * @brief Allocate a new `riak_binary` struct (shallow copy)
+ * @param cfg Riak Configuration
+ * @param bin Original Riak Binary
+ * @returns pointer to newly created `riak_binary` struct
+ */
+riak_binary*
+riak_binary_copy_shallow(riak_config *cfg,
+                         riak_binary *bin);
 
 /**
  * @brief Create a new `riak_binary` from a string

--- a/src/include/riak_binary.h
+++ b/src/include/riak_binary.h
@@ -27,44 +27,45 @@
 typedef struct _riak_binary riak_binary;
 
 /**
- * @brief Allocate a new `riak_binary` struct
+ * @brief Allocate a new `riak_binary` struct (shallow copy)
+ * @param cfg Riak Configuration
  * @param len Length of binary in bytes
- * @param data Pointer to binary data (shallow copy)
+ * @param data Pointer to binary data
  * @returns pointer to newly created `riak_binary` struct
  */
 riak_binary*
-riak_binary_new(riak_config *cfg,
+riak_binary_new(riak_config  *cfg,
                 riak_size_t   len,
                 riak_uint8_t *data);
 
-
 /**
  * @brief Allocate a new `riak_binary` struct
+ * @param cfg Riak Configuration
  * @param bin Original Riak Binary
  * @returns pointer to newly created `riak_binary` struct
  */
 riak_binary*
-riak_binary_deep_new(riak_config *cfg,
-                     riak_binary *bin);
+riak_binary_copy(riak_config *cfg,
+                 riak_binary *bin);
 
 /**
- * @brief Allocate a new riak_binary and populate from data pointer
- * @param bin Existing `riak_binary` to be shallow copied
+ * @brief Create a new `riak_binary` from a string
+ * @param cfg Riak Configuration
+ * @param from NULL-terminated string
  * @returns pointer to newly created `riak_binary` struct
  */
 riak_binary*
-riak_binary_populate(riak_config *cfg,
-                     riak_binary  *bin);
+riak_binary_copy_from_string(riak_config *cfg,
+                             const char  *from);
 
 /**
  * @brief Free allocated memory used by `riak_binary`
+ * @param cfg Riak Configuration
+ * @param bin Existing `riak_binary`
  */
 void
 riak_binary_free(riak_config  *cfg,
-                 riak_binary  **bin);
-void
-riak_binary_deep_free(riak_config  *cfg,
-                      riak_binary  **bin);
+                 riak_binary **bin);
 
 /**
  * @brief Return the length of the binary object
@@ -82,30 +83,28 @@ riak_binary_len(riak_binary *bin);
 riak_uint8_t*
 riak_binary_data(riak_binary *bin);
 
-void
-riak_binary_copy(riak_binary *to,
-                 riak_binary *from);
-riak_error
-riak_binary_deep_copy(riak_config *cfg,
-                      riak_binary  *to,
-                      riak_binary  *from);
-int
+/**
+ * @brief User-readable representation of a binary object
+ * @param bin Riak Binary
+ * @param target Where to write the output
+ * @param len Maximum allowed number of bytes to write
+ * @returns Number of bytes written
+ */
+riak_size_t
 riak_binary_print(riak_binary  *bin,
                   char         *target,
                   riak_uint32_t len);
-int
+
+/**
+ * @brief Hexidecimal representation of a binary object
+ * @param bin Riak Binary
+ * @param target Where to write the output
+ * @param len Maximum allowed number of bytes to write
+ * @returns Number of bytes written
+ */
+riak_size_t
 riak_binary_hex_print(riak_binary  *bin,
                       char         *target,
                       riak_uint32_t len);
-void
-riak_binary_from_string(riak_binary *to,
-                        const char  *from);
-riak_error
-riak_binary_from_string_deep_copy(riak_config *cfg,
-                                  riak_binary  *to,
-                                  const char   *from);
-riak_binary*
-riak_binary_new_from_string(riak_config *cfg,
-                            const char   *from);
 
 #endif // _RIAK_BINARY_H

--- a/src/internal/riak_binary-internal.h
+++ b/src/internal/riak_binary-internal.h
@@ -29,8 +29,9 @@
 
 // Based off of ProtobufCBinaryData
 struct _riak_binary {
-    riak_size_t   len;
-    riak_uint8_t *data;
+    riak_size_t    len;
+    riak_uint8_t  *data;
+    riak_boolean_t managed;
 };
 
 /**

--- a/src/internal/riak_binary-internal.h
+++ b/src/internal/riak_binary-internal.h
@@ -35,36 +35,22 @@ struct _riak_binary {
 
 /**
  * @brief Allocate a new riak_binary and populate from data pointer
+ * @param cfg Riak Configuration
  * @param bin Existing `ProtobufCBinaryData` to be shallow copied
  * @returns pointer to newly created `riak_binary` struct
  */
 riak_binary*
-riak_binary_populate_from_pb(riak_config *cfg,
-                             ProtobufCBinaryData  *bin);
-
-void
-riak_binary_to_pb_copy(ProtobufCBinaryData *to,
-                       riak_binary         *from);
-riak_error
-riak_binary_to_pb_deep_copy(riak_config        *cfg,
-                            ProtobufCBinaryData *to,
-                            riak_binary         *from);
-void
-riak_binary_from_pb_copy(riak_binary        *to,
-                         ProtobufCBinaryData *from);
-riak_error
-riak_binary_from_pb_deep_copy(riak_config        *cfg,
-                              riak_binary         *to,
-                              ProtobufCBinaryData *from);
+riak_binary_copy_from_pb(riak_config         *cfg,
+                         ProtobufCBinaryData *bin);
 
 /**
- * @brief Clean up deeply allocated PB binary
- * @param cfg Riak Configuration
- * @param b Protocol Buffer
+ * @brief Create a shallow copy of `riak_binary` for use in PB
+ * @param to Existing PBC struct
+ * @param from Existing `riak_binary`
  */
 void
-riak_binary_deep_free_pb(riak_config        *cfg,
-                         ProtobufCBinaryData *b);
+riak_binary_copy_to_pb(ProtobufCBinaryData *to,
+                       riak_binary         *from);
 
 #define _RIAK_DUMP_BINARY_HEX(B) { char buffer[10240]; \
     char *dest = buffer; \

--- a/src/messages/riak_2index.c
+++ b/src/messages/riak_2index.c
@@ -42,23 +42,23 @@ riak_2index_request_encode(riak_operation      *rop,
 
     riak_operation_set_bucket(rop, bucket);
     riak_operation_set_index(rop, index);
-    riak_binary_to_pb_copy(&twoimsg.bucket, bucket);
-    riak_binary_to_pb_copy(&twoimsg.index, index);
+    riak_binary_copy_to_pb(&twoimsg.bucket, bucket);
+    riak_binary_copy_to_pb(&twoimsg.index, index);
 
     // process get options
     if (index_options != NULL) {
         twoimsg.qtype = index_options->qtype;
         twoimsg.has_key = index_options->has_key;
         if (index_options->has_key) {
-            riak_binary_to_pb_copy(&twoimsg.key, index_options->key);
+            riak_binary_copy_to_pb(&twoimsg.key, index_options->key);
         }
         twoimsg.has_range_min = index_options->has_range_min;
         if (index_options->has_range_min) {
-            riak_binary_to_pb_copy(&twoimsg.range_min, index_options->range_min);
+            riak_binary_copy_to_pb(&twoimsg.range_min, index_options->range_min);
         }
         twoimsg.has_range_max = index_options->has_range_max;
         if (index_options->has_range_max) {
-            riak_binary_to_pb_copy(&twoimsg.range_max, index_options->range_max);
+            riak_binary_copy_to_pb(&twoimsg.range_max, index_options->range_max);
         }
         twoimsg.has_return_terms = index_options->has_return_terms;
         twoimsg.return_terms = index_options->return_terms;
@@ -68,17 +68,17 @@ riak_2index_request_encode(riak_operation      *rop,
         twoimsg.max_results = index_options->max_results;
         twoimsg.has_continuation = index_options->has_continuation;
         if (index_options->has_continuation) {
-            riak_binary_to_pb_copy(&twoimsg.continuation, index_options->continuation);
+            riak_binary_copy_to_pb(&twoimsg.continuation, index_options->continuation);
         }
         twoimsg.has_timeout = index_options->has_timeout;
         twoimsg.timeout = index_options->timeout;
         twoimsg.has_type = index_options->has_type;
         if (index_options->has_type) {
-            riak_binary_to_pb_copy(&twoimsg.type, index_options->type);
+            riak_binary_copy_to_pb(&twoimsg.type, index_options->type);
         }
         twoimsg.has_term_regex = index_options->has_term_regex;
         if (index_options->has_term_regex) {
-            riak_binary_to_pb_copy(&twoimsg.term_regex, index_options->term_regex);
+            riak_binary_copy_to_pb(&twoimsg.term_regex, index_options->term_regex);
         }
         twoimsg.has_pagination_sort = index_options->has_pagination_sort;
         twoimsg.pagination_sort = index_options->pagination_sort;
@@ -167,7 +167,7 @@ riak_2index_response_decode(riak_operation        *rop,
 
         for(i = 0, j = 0, chunk = 0; i < response->n_keys; i++) {
             RpbIndexResp *rpb_response = response->_internal[chunk];
-            response->keys[i] = riak_binary_populate_from_pb(cfg, &(rpb_response->keys[j]));
+            response->keys[i] = riak_binary_copy_from_pb(cfg, &(rpb_response->keys[j]));
             if (response->keys[i] == NULL) {
                 riak_free(cfg, &(response->keys));
                 return ERIAK_OUT_OF_MEMORY;
@@ -197,7 +197,7 @@ riak_2index_response_decode(riak_operation        *rop,
     // Is this correct?  This would only be from the last message
     RpbIndexResp *rpb_response = response->_internal[response->_n_responses-1];
     response->has_continuation = rpb_response->has_continuation;
-    response->continuation = riak_binary_populate_from_pb(cfg, &(rpb_response->continuation));
+    response->continuation = riak_binary_copy_from_pb(cfg, &(rpb_response->continuation));
     response->has_done = rpb_response->has_done;
     response->done = rpb_response->done;
 
@@ -440,7 +440,7 @@ riak_2index_options_set_key(riak_config         *cfg,
                             riak_2index_options *opt,
                             riak_binary         *value) {
     opt->has_key = RIAK_TRUE;
-    opt->key = riak_binary_deep_new(cfg, value);
+    opt->key = riak_binary_copy(cfg, value);
     if (opt->key == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -452,7 +452,7 @@ riak_2index_options_set_range_min(riak_config         *cfg,
                                   riak_2index_options *opt,
                                   riak_binary         *value) {
     opt->has_range_min = RIAK_TRUE;
-    opt->range_min = riak_binary_deep_new(cfg, value);
+    opt->range_min = riak_binary_copy(cfg, value);
     if (opt->range_min == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -464,7 +464,7 @@ riak_2index_options_set_range_max(riak_config         *cfg,
                                   riak_2index_options *opt,
                                   riak_binary         *value) {
     opt->has_range_max = RIAK_TRUE;
-    opt->range_max = riak_binary_deep_new(cfg, value);
+    opt->range_max = riak_binary_copy(cfg, value);
     if (opt->range_max == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -497,7 +497,7 @@ riak_2index_options_set_continuation(riak_config         *cfg,
                                      riak_2index_options *opt,
                                      riak_binary         *value) {
     opt->has_continuation = RIAK_TRUE;
-    opt->continuation = riak_binary_deep_new(cfg, value);
+    opt->continuation = riak_binary_copy(cfg, value);
     if (opt->continuation == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -516,7 +516,7 @@ riak_2index_options_set_type(riak_config         *cfg,
                              riak_2index_options *opt,
                              riak_binary         *value) {
     opt->has_type = RIAK_TRUE;
-    opt->type = riak_binary_deep_new(cfg, value);
+    opt->type = riak_binary_copy(cfg, value);
     if (opt->type == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -528,7 +528,7 @@ riak_2index_options_set_term_regex(riak_config         *cfg,
                                    riak_2index_options *opt,
                                    riak_binary         *value) {
     opt->has_term_regex = RIAK_TRUE;
-    opt->term_regex = riak_binary_deep_new(cfg, value);
+    opt->term_regex = riak_binary_copy(cfg, value);
     if (opt->term_regex == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }

--- a/src/messages/riak_delete.c
+++ b/src/messages/riak_delete.c
@@ -41,8 +41,8 @@ riak_delete_request_encode(riak_operation      *rop,
     riak_config *cfg = riak_operation_get_config(rop);
     RpbDelReq delmsg = RPB_DEL_REQ__INIT;
 
-    riak_binary_to_pb_copy(&delmsg.bucket, bucket);
-    riak_binary_to_pb_copy(&delmsg.key, key);
+    riak_binary_copy_to_pb(&delmsg.bucket, bucket);
+    riak_binary_copy_to_pb(&delmsg.key, key);
 
     // process delete options
     if (options != NULL) {
@@ -69,7 +69,7 @@ riak_delete_request_encode(riak_operation      *rop,
         }
         if (options->has_vclock) {
             delmsg.has_vclock = RIAK_TRUE;
-            riak_binary_to_pb_copy(&delmsg.vclock, options->vclock);
+            riak_binary_copy_to_pb(&delmsg.vclock, options->vclock);
         }
         if (options->has_w) {
             delmsg.has_w = RIAK_TRUE;
@@ -230,7 +230,7 @@ riak_delete_options_set_vclock(riak_config      *cfg,
     if (opt->vclock) {
         riak_free(cfg, &opt->vclock);
     }
-    opt->vclock = riak_binary_deep_new(cfg, value);
+    opt->vclock = riak_binary_copy(cfg, value);
 }
 void
 riak_delete_options_set_w(riak_delete_options *opt,

--- a/src/messages/riak_error.c
+++ b/src/messages/riak_error.c
@@ -50,7 +50,7 @@ riak_decode_error_response(riak_operation       *rop,
     }
     response->_internal = errresp;
     response->errcode = errresp->errcode;
-    response->errmsg = riak_binary_populate_from_pb(cfg, &(errresp->errmsg));
+    response->errmsg = riak_binary_copy_from_pb(cfg, &(errresp->errmsg));
     if (response->errmsg == NULL) {
         riak_free(cfg, &response);
         rpb_error_resp__free_unpacked(errresp, cfg->pb_allocator);

--- a/src/messages/riak_get.c
+++ b/src/messages/riak_get.c
@@ -43,8 +43,8 @@ riak_get_request_encode(riak_operation  *rop,
 
     riak_operation_set_bucket(rop, bucket);
     riak_operation_set_key(rop, key);
-    riak_binary_to_pb_copy(&getmsg.bucket, bucket);
-    riak_binary_to_pb_copy(&getmsg.key, key);
+    riak_binary_copy_to_pb(&getmsg.bucket, bucket);
+    riak_binary_copy_to_pb(&getmsg.key, key);
 
     // process get options
     if(get_options != NULL) {
@@ -58,7 +58,7 @@ riak_get_request_encode(riak_operation  *rop,
         getmsg.notfound_ok = get_options->notfound_ok;
         if (get_options->has_if_modified) {
             getmsg.has_if_modified = get_options->has_if_modified;
-            riak_binary_to_pb_copy(&getmsg.if_modified, get_options->if_modified);
+            riak_binary_copy_to_pb(&getmsg.if_modified, get_options->if_modified);
         }
         getmsg.has_head = get_options->has_head;
         getmsg.head = get_options->head;
@@ -114,7 +114,7 @@ riak_get_response_decode(riak_operation     *rop,
 
     if (rpbresp->has_vclock) {
         response->has_vclock = RIAK_TRUE;
-        response->vclock = riak_binary_populate_from_pb(cfg, &(rpbresp->vclock));
+        response->vclock = riak_binary_copy_from_pb(cfg, &(rpbresp->vclock));
         if (response->vclock == NULL) {
             riak_free(cfg, &response);
             return ERIAK_OUT_OF_MEMORY;
@@ -139,8 +139,8 @@ riak_get_response_decode(riak_operation     *rop,
                 riak_free(cfg, &response);
                 return err;
             }
-            response->content[i]->bucket  = riak_binary_deep_new(cfg, riak_operation_get_bucket(rop));
-            response->content[i]->key     = riak_binary_deep_new(cfg, riak_operation_get_key(rop));
+            response->content[i]->bucket  = riak_binary_copy(cfg, riak_operation_get_bucket(rop));
+            response->content[i]->key     = riak_binary_copy(cfg, riak_operation_get_key(rop));
             response->content[i]->has_key = RIAK_TRUE;
         }
     }
@@ -399,7 +399,7 @@ riak_get_options_set_if_modified(riak_config      *cfg,
     if (opt->if_modified) {
         riak_free(cfg, &opt->if_modified);
     }
-    opt->if_modified =  riak_binary_deep_new(cfg, value);
+    opt->if_modified =  riak_binary_copy(cfg, value);
 }
 void
 riak_get_options_set_head(riak_get_options *opt,

--- a/src/messages/riak_get_bucketprops.c
+++ b/src/messages/riak_get_bucketprops.c
@@ -39,7 +39,7 @@ riak_get_bucketprops_request_encode(riak_operation   *rop,
     RpbGetBucketReq bucketreq;
     rpb_get_bucket_req__init(&bucketreq);
 
-    riak_binary_to_pb_copy(&(bucketreq.bucket), bucket);
+    riak_binary_copy_to_pb(&(bucketreq.bucket), bucket);
     riak_size_t msglen = rpb_get_bucket_req__get_packed_size(&bucketreq);
     riak_uint8_t *msgbuf = (riak_uint8_t*)(cfg->malloc_fn)(msglen);
     if (msgbuf == NULL) {

--- a/src/messages/riak_get_clientid.c
+++ b/src/messages/riak_get_clientid.c
@@ -69,7 +69,7 @@ riak_get_clientid_response_decode(riak_operation              *rop,
     memset(response, '\0', sizeof(riak_get_clientid_response));
     response->_internal = rpbresp;
 
-    response->client_id = riak_binary_populate_from_pb(cfg, &(rpbresp->client_id));
+    response->client_id = riak_binary_copy_from_pb(cfg, &(rpbresp->client_id));
     if (response->client_id == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }

--- a/src/messages/riak_listkeys.c
+++ b/src/messages/riak_listkeys.c
@@ -38,7 +38,7 @@ riak_listkeys_request_encode(riak_operation   *rop,
     riak_config *cfg = riak_operation_get_config(rop);
     RpbListKeysReq listkeysreq = RPB_LIST_KEYS_REQ__INIT;
 
-    riak_binary_to_pb_copy(&(listkeysreq.bucket), bucket);
+    riak_binary_copy_to_pb(&(listkeysreq.bucket), bucket);
     if (timeout > 0) {
         listkeysreq.has_timeout = RIAK_TRUE;
         listkeysreq.timeout = timeout;

--- a/src/messages/riak_mapreduce.c
+++ b/src/messages/riak_mapreduce.c
@@ -40,8 +40,8 @@ riak_mapreduce_request_encode(riak_operation   *rop,
     riak_config *cfg = riak_operation_get_config(rop);
     RpbMapRedReq mapmsg = RPB_MAP_RED_REQ__INIT;
 
-    riak_binary_to_pb_copy(&mapmsg.request, map_request);
-    riak_binary_to_pb_copy(&mapmsg.content_type, content_type);
+    riak_binary_copy_to_pb(&mapmsg.request, map_request);
+    riak_binary_copy_to_pb(&mapmsg.content_type, content_type);
 
     riak_uint32_t msglen = rpb_map_red_req__get_packed_size (&mapmsg);
     riak_uint8_t* msgbuf = (riak_uint8_t*)(cfg->malloc_fn)(msglen);
@@ -127,7 +127,7 @@ riak_mapreduce_response_decode(riak_operation           *rop,
             msg->has_phase = rpb_response->has_phase;
             msg->phase = rpb_response->phase;
             msg->has_response = rpb_response->has_response;
-            msg->response = riak_binary_populate_from_pb(cfg, &(rpb_response->response));
+            msg->response = riak_binary_copy_from_pb(cfg, &(rpb_response->response));
         }
     }
 

--- a/src/messages/riak_put.c
+++ b/src/messages/riak_put.c
@@ -39,12 +39,12 @@ riak_put_request_encode(riak_operation   *rop,
     riak_config *cfg = riak_operation_get_config(rop);
     RpbPutReq putmsg = RPB_PUT_REQ__INIT;
 
-    riak_binary_to_pb_copy(&(putmsg.bucket), riak_obj->bucket);
+    riak_binary_copy_to_pb(&(putmsg.bucket), riak_obj->bucket);
 
     // Is the Key provided?
     if (riak_obj->has_key) {
         putmsg.has_key = RIAK_TRUE;
-        riak_binary_to_pb_copy(&(putmsg.key), riak_obj->key);
+        riak_binary_copy_to_pb(&(putmsg.key), riak_obj->key);
     }
 
     // Data content payload
@@ -96,7 +96,7 @@ riak_put_request_encode(riak_operation   *rop,
         }
         if (options->has_vclock) {
             putmsg.has_vclock = RIAK_TRUE;
-            riak_binary_to_pb_copy(&(putmsg.vclock), options->vclock);
+            riak_binary_copy_to_pb(&(putmsg.vclock), options->vclock);
         }
         if (options->has_w) {
             putmsg.has_w = RIAK_TRUE;
@@ -156,14 +156,14 @@ riak_put_response_decode(riak_operation     *rop,
     response->_internal = rpbresp;
     if (rpbresp->has_vclock) {
         response->has_vclock = RIAK_TRUE;
-        response->vclock = riak_binary_populate_from_pb(cfg, &(rpbresp->vclock));
+        response->vclock = riak_binary_copy_from_pb(cfg, &(rpbresp->vclock));
         if (response->vclock == NULL) {
             return ERIAK_OUT_OF_MEMORY;
         }
     }
     if (rpbresp->has_key) {
         response->has_key = RIAK_TRUE;
-        response->key = riak_binary_populate_from_pb(cfg, &(rpbresp->key));
+        response->key = riak_binary_copy_from_pb(cfg, &(rpbresp->key));
         if (response->key == NULL) {
             return ERIAK_OUT_OF_MEMORY;
         }
@@ -432,7 +432,7 @@ riak_put_options_set_vclock(riak_config      *cfg,
     if (opt->vclock) {
         riak_free(cfg, &opt->vclock);
     }
-    opt->vclock = riak_binary_deep_new(cfg, value);
+    opt->vclock = riak_binary_copy(cfg, value);
 }
 void
 riak_put_options_set_w(riak_put_options *opt,

--- a/src/messages/riak_reset_bucketprops.c
+++ b/src/messages/riak_reset_bucketprops.c
@@ -40,7 +40,7 @@ riak_reset_bucketprops_request_encode(riak_operation      *rop,
     RpbResetBucketReq resetmsg;
     rpb_reset_bucket_req__init(&resetmsg);
 
-    riak_binary_to_pb_copy(&resetmsg.bucket, bucket);
+    riak_binary_copy_to_pb(&resetmsg.bucket, bucket);
 
     riak_uint32_t msglen = rpb_reset_bucket_req__get_packed_size(&resetmsg);
     riak_uint8_t* msgbuf = (riak_uint8_t*)(cfg->malloc_fn)(msglen);

--- a/src/messages/riak_search.c
+++ b/src/messages/riak_search.c
@@ -42,8 +42,8 @@ riak_search_request_encode(riak_operation      *rop,
     RpbSearchQueryReq srchmsg = RPB_SEARCH_QUERY_REQ__INIT;
 
     riak_operation_set_bucket(rop, bucket);
-    riak_binary_to_pb_copy(&srchmsg.q, query);
-    riak_binary_to_pb_copy(&srchmsg.index, bucket);
+    riak_binary_copy_to_pb(&srchmsg.q, query);
+    riak_binary_copy_to_pb(&srchmsg.index, bucket);
 
     // process get options
     if(search_options != NULL) {
@@ -53,23 +53,23 @@ riak_search_request_encode(riak_operation      *rop,
         srchmsg.start = search_options->start;
         if (search_options->has_sort) {
             srchmsg.has_sort = search_options->has_sort;
-            riak_binary_to_pb_copy(&srchmsg.sort, search_options->sort);
+            riak_binary_copy_to_pb(&srchmsg.sort, search_options->sort);
         }
         if (search_options->has_filter) {
             srchmsg.has_filter = search_options->has_filter;
-            riak_binary_to_pb_copy(&srchmsg.filter, search_options->filter);
+            riak_binary_copy_to_pb(&srchmsg.filter, search_options->filter);
         }
         if (search_options->has_df) {
             srchmsg.has_df = search_options->has_df;
-            riak_binary_to_pb_copy(&srchmsg.df, search_options->df);
+            riak_binary_copy_to_pb(&srchmsg.df, search_options->df);
         }
         if (search_options->has_df) {
             srchmsg.has_op = search_options->has_op;
-            riak_binary_to_pb_copy(&srchmsg.op, search_options->op);
+            riak_binary_copy_to_pb(&srchmsg.op, search_options->op);
         }
         if (search_options->has_presort) {
             srchmsg.has_presort = search_options->has_presort;
-            riak_binary_to_pb_copy(&srchmsg.presort, search_options->presort);
+            riak_binary_copy_to_pb(&srchmsg.presort, search_options->presort);
         }
         if (search_options->n_fl > 0) {
             srchmsg.n_fl = search_options->n_fl;
@@ -78,7 +78,7 @@ riak_search_request_encode(riak_operation      *rop,
                 return ERIAK_OUT_OF_MEMORY;
             }
             for(int i = 0; i < search_options->n_fl; i++) {
-                riak_binary_to_pb_copy(&(srchmsg.fl[i]), search_options->fl[i]);
+                riak_binary_copy_to_pb(&(srchmsg.fl[i]), search_options->fl[i]);
             }
         }
     }
@@ -330,7 +330,7 @@ riak_search_options_set_sort(riak_config                *cfg,
     if (opt->sort) {
         riak_free(cfg, &opt->sort);
     }
-    opt->sort =  riak_binary_deep_new(cfg, value);
+    opt->sort =  riak_binary_copy(cfg, value);
     if (opt->sort == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -345,7 +345,7 @@ riak_search_options_set_filter(riak_config                *cfg,
     if (opt->filter) {
         riak_free(cfg, &opt->filter);
     }
-    opt->filter =  riak_binary_deep_new(cfg, value);
+    opt->filter =  riak_binary_copy(cfg, value);
     if (opt->filter == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -360,7 +360,7 @@ riak_search_options_set_df(riak_config         *cfg,
     if (opt->df) {
         riak_free(cfg, &opt->df);
     }
-    opt->df =  riak_binary_deep_new(cfg, value);
+    opt->df =  riak_binary_copy(cfg, value);
     if (opt->df == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -375,7 +375,7 @@ riak_search_options_set_op(riak_config                *cfg,
     if (opt->op) {
         riak_free(cfg, &opt->op);
     }
-    opt->op =  riak_binary_deep_new(cfg, value);
+    opt->op =  riak_binary_copy(cfg, value);
     if (opt->op == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -398,7 +398,7 @@ riak_search_options_add_fl(riak_config         *cfg,
     if (opt->fl == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
-    opt->fl[opt->n_fl] = riak_binary_deep_new(cfg, value);
+    opt->fl[opt->n_fl] = riak_binary_copy(cfg, value);
     if (opt->fl[opt->n_fl] == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     } else {
@@ -416,7 +416,7 @@ riak_search_options_set_presort(riak_config         *cfg,
     if (opt->presort) {
         riak_free(cfg, &opt->presort);
     }
-    opt->presort =  riak_binary_deep_new(cfg, value);
+    opt->presort =  riak_binary_copy(cfg, value);
     if (opt->presort == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }

--- a/src/messages/riak_serverinfo.c
+++ b/src/messages/riak_serverinfo.c
@@ -70,14 +70,14 @@ riak_serverinfo_response_decode(riak_operation            *rop,
 
     if (rpbresp->has_node) {
         response->has_node = RIAK_TRUE;
-        response->node = riak_binary_populate_from_pb(cfg, &(rpbresp->node));
+        response->node = riak_binary_copy_from_pb(cfg, &(rpbresp->node));
         if (response->node == NULL) {
             return ERIAK_OUT_OF_MEMORY;
         }
     }
     if (rpbresp->has_server_version) {
         response->has_server_version = RIAK_TRUE;
-        response->server_version = riak_binary_populate_from_pb(cfg, &(rpbresp->server_version));
+        response->server_version = riak_binary_copy_from_pb(cfg, &(rpbresp->server_version));
         if (response->server_version == NULL) {
             return ERIAK_OUT_OF_MEMORY;
         }

--- a/src/messages/riak_set_bucketprops.c
+++ b/src/messages/riak_set_bucketprops.c
@@ -41,7 +41,7 @@ riak_set_bucketprops_request_encode(riak_operation      *rop,
     RpbSetBucketReq setmsg;
     rpb_set_bucket_req__init(&setmsg);
 
-    riak_binary_to_pb_copy(&setmsg.bucket, bucket);
+    riak_binary_copy_to_pb(&setmsg.bucket, bucket);
     RpbBucketProps pbprops;
     riak_bucketprops_to_pb_copy(cfg, &pbprops, props);
     setmsg.props = &pbprops;

--- a/src/messages/riak_set_clientid.c
+++ b/src/messages/riak_set_clientid.c
@@ -53,7 +53,7 @@ riak_set_clientid_request_encode(riak_operation  *rop,
 
     riak_config *cfg = riak_operation_get_config(rop);
     RpbSetClientIdReq clidmsg = RPB_SET_CLIENT_ID_REQ__INIT;
-    riak_binary_to_pb_copy(&(clidmsg.client_id), clientid);
+    riak_binary_copy_to_pb(&(clidmsg.client_id), clientid);
 
     riak_uint32_t msglen = rpb_set_client_id_req__get_packed_size(&clidmsg);
     riak_uint8_t* msgbuf = (riak_uint8_t*)(cfg->malloc_fn)(msglen);

--- a/src/riak_binary.c
+++ b/src/riak_binary.c
@@ -30,39 +30,46 @@ riak_binary*
 riak_binary_new(riak_config  *cfg,
                 riak_size_t   len,
                 riak_uint8_t *data) {
-    riak_binary *b = (riak_binary*)riak_config_allocate(cfg, sizeof(riak_binary));
-    if (b == NULL) return NULL;
-    b->len  = len;
-    b->data = data;
-
-    return b;
-}
-
-riak_binary*
-riak_binary_deep_new(riak_config *cfg,
-                     riak_binary *bin) {
-
-    riak_binary *b = riak_binary_new(cfg, bin->len, bin->data);
+    riak_binary *b = riak_config_allocate(cfg, sizeof(riak_binary));
+    // In the degenerate case, force the length to be zero
+    if (data == NULL) {
+        len = 0;
+    }
     if (b) {
-        b->data = (riak_uint8_t*)riak_config_allocate(cfg, bin->len);
-        memcpy((void*)b->data, (void*)bin->data, bin->len);
+        b->len  = len;
+        b->data = riak_config_allocate(cfg, len);
+        if (b->data) {
+            memcpy((void*)b->data, (void*)data, len);
+        } else {
+            riak_free(cfg, &b);
+        }
     }
     return b;
 }
 
-
 riak_binary*
-riak_binary_populate(riak_config *cfg,
-                     riak_binary *b) {
-    return riak_binary_new(cfg, b->len, b->data);
+riak_binary_copy(riak_config *cfg,
+                 riak_binary *bin) {
+    if (bin == NULL) {
+        return NULL;
+    }
+    return riak_binary_new(cfg, bin->len, bin->data);
 }
 
 riak_binary*
-riak_binary_populate_from_pb(riak_config         *cfg,
-                             ProtobufCBinaryData *b) {
-    return riak_binary_new(cfg, b->len, b->data);
+riak_binary_copy_from_string(riak_config *cfg,
+                             const char  *from) {
+    if (from == NULL) {
+        return NULL;
+    }
+    return riak_binary_new(cfg, strlen(from), (riak_uint8_t*)from);
 }
 
+riak_binary*
+riak_binary_copy_from_pb(riak_config         *cfg,
+                         ProtobufCBinaryData *b) {
+    return riak_binary_new(cfg, b->len, b->data);
+}
 
 riak_size_t
 riak_binary_len(riak_binary *bin) {
@@ -77,16 +84,7 @@ riak_binary_data(riak_binary *bin) {
 void
 riak_binary_free(riak_config  *cfg,
                  riak_binary **b) {
-      if (b == NULL) {
-          return;
-      }
-      riak_free(cfg, b);
-}
-
-void
-riak_binary_deep_free(riak_config  *cfg,
-                      riak_binary **b) {
-      if (b == NULL) {
+      if (b == NULL || *b == NULL) {
           return;
       }
       riak_free(cfg, &((*b)->data));
@@ -94,74 +92,18 @@ riak_binary_deep_free(riak_config  *cfg,
 }
 
 void
-riak_binary_deep_free_pb(riak_config        *cfg,
-                         ProtobufCBinaryData *b) {
-      if (b == NULL) {
-          return;
-      }
-      riak_free(cfg, &(b->data));
-}
-
-void
-riak_binary_copy(riak_binary* to,
-                 riak_binary* from) {
-    to->len  = from->len;
-    to->data = from->data;
-}
-
-riak_error
-riak_binary_deep_copy(riak_config *cfg,
-                      riak_binary *to,
-                      riak_binary *from) {
-    to->len  = from->len;
-    to->data = (riak_uint8_t*)riak_config_allocate(cfg, from->len);
-    if (to->data == NULL) return ERIAK_OUT_OF_MEMORY;
-    memcpy((void*)to->data, (void*)from->data, from->len);
-    return ERIAK_OK;
-}
-
-void
-riak_binary_to_pb_copy(ProtobufCBinaryData *to,
+riak_binary_copy_to_pb(ProtobufCBinaryData *to,
                        riak_binary         *from) {
     to->len  = from->len;
     to->data = from->data;
 }
 
-riak_error
-riak_binary_to_pb_deep_copy(riak_config         *cfg,
-                            ProtobufCBinaryData *to,
-                            riak_binary         *from) {
-    to->len  = from->len;
-    to->data = (riak_uint8_t*)riak_config_allocate(cfg, from->len);
-    if (to->data == NULL) return ERIAK_OUT_OF_MEMORY;
-    memcpy((void*)to->data, (void*)from->data, from->len);
-    return ERIAK_OK;
-}
-
-void
-riak_binary_from_pb_copy(riak_binary         *to,
-                         ProtobufCBinaryData *from) {
-    to->len  = from->len;
-    to->data = from->data;
-}
-
-riak_error
-riak_binary_from_pb_deep_copy(riak_config         *cfg,
-                              riak_binary         *to,
-                              ProtobufCBinaryData *from) {
-    to->len  = from->len;
-    to->data = (riak_uint8_t*)riak_config_allocate(cfg, from->len);
-    if (to->data == NULL) return ERIAK_OUT_OF_MEMORY;
-    memcpy((void*)to->data, (void*)from->data, from->len);
-    return ERIAK_OK;
-}
-
 //TODO: Figure out clean way to print UTF-8 encoding
-int
+riak_size_t
 riak_binary_print(riak_binary *bin,
                   char         *target,
                   riak_uint32_t len) {
-    int i = 0;
+    riak_size_t i = 0;
     for( ; (bin) && (i < (bin->len)) && i < (len-1); i++) {
         char c = '.';
         // Non-printable characters are replaced by a dot
@@ -174,11 +116,11 @@ riak_binary_print(riak_binary *bin,
     return i;
 }
 
-int
+riak_size_t
 riak_binary_hex_print(riak_binary  *bin,
                       char         *target,
                       riak_uint32_t len) {
-    int count = 0;
+    riak_size_t count = 0;
     static char hex[] = "0123456789abcdef";
     if (bin != NULL) {
         for( ; count < bin->len && (count*2) < len-1; count++) {
@@ -191,34 +133,5 @@ riak_binary_hex_print(riak_binary  *bin,
     }
     if (len > 0) target[count*2] = '\0';
     return count*2;
-}
-
-void
-riak_binary_from_string(riak_binary *to,
-                        const char  *from) {
-    to->data = (riak_uint8_t*)from;
-    to->len = strlen(from);
-}
-
-riak_error
-riak_binary_from_string_deep_copy(riak_config *cfg,
-                                  riak_binary *to,
-                                  const char  *from) {
-
-    to->len = strlen(from);
-    to->data = (riak_uint8_t*)riak_config_allocate(cfg, to->len);
-    if (to->data == NULL) return ERIAK_OUT_OF_MEMORY;
-    memcpy((void*)to->data, (void*)from, to->len);
-    return ERIAK_OK;
-}
-
-riak_binary*
-riak_binary_new_from_string(riak_config  *cfg,
-                            const char   *from) {
-    riak_binary *b = riak_binary_new(cfg, 0, NULL);
-    if (b != NULL) {
-        riak_binary_from_string(b, from);
-    }
-    return b;
 }
 

--- a/src/riak_binary.c
+++ b/src/riak_binary.c
@@ -49,12 +49,46 @@ riak_binary_new(riak_config  *cfg,
 }
 
 riak_binary*
+riak_binary_new_shallow(riak_config  *cfg,
+                        riak_size_t   len,
+                        riak_uint8_t *data) {
+    riak_binary *b = riak_config_allocate(cfg, sizeof(riak_binary));
+    // In the degenerate case, force the length to be zero
+    if (data == NULL) {
+        len = 0;
+    }
+    if (b) {
+        b->len     = len;
+        b->data    = data;
+        b->managed = RIAK_FALSE;
+    }
+    return b;
+}
+
+riak_binary*
 riak_binary_copy(riak_config *cfg,
                  riak_binary *bin) {
     if (bin == NULL) {
         return NULL;
     }
     return riak_binary_new(cfg, bin->len, bin->data);
+}
+
+riak_binary*
+riak_binary_copy_shallow(riak_config *cfg,
+                         riak_binary *bin) {
+    riak_size_t  len = bin->len;
+    riak_binary *b   = riak_config_allocate(cfg, sizeof(riak_binary));
+    // In the degenerate case, force the length to be zero
+    if (bin->data == NULL) {
+        len = 0;
+    }
+    if (b) {
+        b->len     = len;
+        b->data    = bin->data;
+        b->managed = RIAK_FALSE;
+    }
+    return b;
 }
 
 riak_binary*

--- a/src/riak_binary.c
+++ b/src/riak_binary.c
@@ -80,6 +80,7 @@ riak_binary_copy_from_pb(riak_config         *cfg,
         b->data    = bin->data;
         b->managed = RIAK_FALSE;
     }
+    return b;
 }
 
 riak_size_t

--- a/src/riak_bucketprops.c
+++ b/src/riak_bucketprops.c
@@ -53,12 +53,12 @@ riak_modfun_deep_new(riak_config *cfg,
     if (fun == NULL) {
         return NULL;
     }
-    fun->module = riak_binary_deep_new(cfg, from->module);
+    fun->module = riak_binary_copy(cfg, from->module);
     if (fun->module == NULL) {
         riak_free(cfg, &fun);
         return NULL;
     }
-    fun->function = riak_binary_deep_new(cfg, from->function);
+    fun->function = riak_binary_copy(cfg, from->function);
     if (fun->function == NULL) {
         riak_binary_free(cfg, &(fun->module));
         riak_free(cfg, &fun);
@@ -79,8 +79,8 @@ riak_modfun_copy_to_pb(riak_config   *cfg,
     if (pbmod_fun == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
-    riak_binary_to_pb_copy(&(pbmod_fun->module), mod_fun->module);
-    riak_binary_to_pb_copy(&(pbmod_fun->function), mod_fun->function);
+    riak_binary_copy_to_pb(&(pbmod_fun->module), mod_fun->module);
+    riak_binary_copy_to_pb(&(pbmod_fun->function), mod_fun->function);
     // Finally assign the pointer to the list of mod_fun pointers
     *pbmod_fun_target = pbmod_fun;
 
@@ -95,11 +95,11 @@ riak_modfun_copy_from_pb(riak_config   *cfg,
     if (pbmod_fun == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
-    mod_fun->module = riak_binary_populate_from_pb(cfg, &(pbmod_fun->module));
+    mod_fun->module = riak_binary_copy_from_pb(cfg, &(pbmod_fun->module));
     if (mod_fun->module == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
-    mod_fun->function = riak_binary_populate_from_pb(cfg, &(pbmod_fun->function));
+    mod_fun->function = riak_binary_copy_from_pb(cfg, &(pbmod_fun->function));
     if (mod_fun->function == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -164,7 +164,7 @@ riak_error
 riak_modfun_set_module(riak_config  *cfg,
                         riak_modfun *mod_fun,
                         riak_binary *value) {
-    mod_fun->module = riak_binary_deep_new(cfg, value);
+    mod_fun->module = riak_binary_copy(cfg, value);
     if (mod_fun->module == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -175,7 +175,7 @@ riak_error
 riak_modfun_set_function(riak_config  *cfg,
                           riak_modfun *mod_fun,
                           riak_binary  *value) {
-    mod_fun->function = riak_binary_deep_new(cfg, value);
+    mod_fun->function = riak_binary_copy(cfg, value);
     if (mod_fun->function == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -229,7 +229,7 @@ riak_commit_hooks_copy_to_pb(riak_config       *cfg,
         memset(pbhook[i], '\0', sizeof(RpbCommitHook));
         if (hook[i]->has_name) {
             pbhook[i]->has_name = RIAK_TRUE;
-            riak_binary_to_pb_copy(&(pbhook[i]->name), hook[i]->name);
+            riak_binary_copy_to_pb(&(pbhook[i]->name), hook[i]->name);
         }
         riak_error err = riak_modfun_copy_to_pb(cfg, &(pbhook[i]->modfun), hook[i]->modfun);
         if (err) {
@@ -260,7 +260,7 @@ riak_commit_hooks_copy_from_pb(riak_config         *cfg,
         memset(hook[i], '\0', sizeof(riak_commit_hook));
         if (pbhook[i]->has_name) {
             hook[i]->has_name = RIAK_TRUE;
-            hook[i]->name = riak_binary_populate_from_pb(cfg, &(pbhook[i]->name));
+            hook[i]->name = riak_binary_copy_from_pb(cfg, &(pbhook[i]->name));
             if (hook[i]->name == NULL) {
                 return ERIAK_OUT_OF_MEMORY;
             }
@@ -355,7 +355,7 @@ riak_commit_hook_set_name(riak_config      *cfg,
                           riak_commit_hook *hook,
                           riak_binary      *value) {
     hook->has_name = RIAK_TRUE;
-    hook->name = riak_binary_deep_new(cfg, value);
+    hook->name = riak_binary_copy(cfg, value);
     if (hook->name == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
@@ -473,7 +473,7 @@ riak_bucketprops_to_pb_copy(riak_config       *cfg,
     }
     if (from->has_backend) {
         to->has_backend = RIAK_TRUE;
-        riak_binary_to_pb_copy(&(to->backend), from->backend);
+        riak_binary_copy_to_pb(&(to->backend), from->backend);
     }
     if (from->has_search) {
         to->has_search = RIAK_TRUE;
@@ -485,7 +485,7 @@ riak_bucketprops_to_pb_copy(riak_config       *cfg,
     }
     if (from->has_search_index) {
         to->has_search_index = RIAK_TRUE;
-        riak_binary_to_pb_copy(&(to->search_index), from->search_index);
+        riak_binary_copy_to_pb(&(to->search_index), from->search_index);
     }
 
     riak_error err = riak_modfun_copy_to_pb(cfg, &(to->chash_keyfun), from->chash_keyfun);
@@ -601,7 +601,7 @@ riak_bucketprops_new_from_pb(riak_config        *cfg,
     }
     if (from->has_backend) {
         to->has_backend = RIAK_TRUE;
-        to->backend = riak_binary_populate_from_pb(cfg, &(from->backend));
+        to->backend = riak_binary_copy_from_pb(cfg, &(from->backend));
         if (to->backend == NULL) {
             riak_free(cfg, target);
             return ERIAK_OUT_OF_MEMORY;
@@ -616,7 +616,7 @@ riak_bucketprops_new_from_pb(riak_config        *cfg,
     }
     if (from->has_search_index) {
         to->has_search_index = RIAK_TRUE;
-        to->search_index = riak_binary_populate_from_pb(cfg, &(from->search_index));
+        to->search_index = riak_binary_copy_from_pb(cfg, &(from->search_index));
         if (to->search_index == NULL) {
             riak_free(cfg, target);
             return ERIAK_OUT_OF_MEMORY;

--- a/src/riak_error.c
+++ b/src/riak_error.c
@@ -42,7 +42,7 @@ riak_server_error_new(struct _riak_config  *cfg,
     }
     *err = error;
     error->errcode = errcode;
-    error->errmsg = riak_binary_deep_new(cfg, errmsg);
+    error->errmsg = riak_binary_copy(cfg, errmsg);
 
     if (error->errmsg == NULL) {
         riak_free(cfg, err);
@@ -56,7 +56,7 @@ void
 riak_server_error_free(struct _riak_config  *cfg,
                        riak_server_error   **err) {
     if (err == NULL || *err == NULL) return;
-    riak_binary_deep_free(cfg, &((*err)->errmsg));
+    riak_binary_free(cfg, &((*err)->errmsg));
     riak_free(cfg, err);
 }
 

--- a/src/riak_object.c
+++ b/src/riak_object.c
@@ -70,7 +70,7 @@ riak_pairs_copy_to_pb(riak_config  *cfg,
             return ERIAK_OUT_OF_MEMORY;
         }
         
-        riak_binary_to_pb_copy(&(pbpair[i]->key), pair[i]->key);
+        riak_binary_copy_to_pb(&(pbpair[i]->key), pair[i]->key);
         
         if (pair[i]->has_value) {
             pbpair[i]->has_value = RIAK_TRUE;

--- a/src/riak_object.c
+++ b/src/riak_object.c
@@ -69,7 +69,7 @@ riak_pairs_copy_to_pb(riak_config  *cfg,
         }
         if (pair[i]->has_value) {
             pbpair[i]->has_value = RIAK_TRUE;
-            riak_binary_to_pb_copy(&(pbpair[i]->value), pair[i]->value);
+            riak_binary_copy_to_pb(&(pbpair[i]->value), pair[i]->value);
         }
     }
     // Finally assign the pointer to the list of pair pointers
@@ -99,13 +99,13 @@ riak_pairs_copy_from_pb(riak_config *cfg,
     if (pair == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
-    pair->key = riak_binary_populate_from_pb(cfg, &(pbpair->key));
+    pair->key = riak_binary_copy_from_pb(cfg, &(pbpair->key));
     if (pair->key == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
     if (pbpair->has_value) {
         pair->has_value = RIAK_TRUE;
-        pair->value = riak_binary_populate_from_pb(cfg, &(pbpair->value));
+        pair->value = riak_binary_copy_from_pb(cfg, &(pbpair->value));
         if (pair->value == NULL) {
             return ERIAK_OUT_OF_MEMORY;
         }
@@ -200,15 +200,15 @@ riak_links_copy_to_pb(riak_config  *cfg,
         memset(pblink[i], '\0', sizeof(RpbLink));
         if (link[i]->has_bucket) {
             pblink[i]->has_bucket = RIAK_TRUE;
-            riak_binary_to_pb_copy(&(pblink[i]->bucket), link[i]->bucket);
+            riak_binary_copy_to_pb(&(pblink[i]->bucket), link[i]->bucket);
         }
         if (link[i]->has_key) {
             pblink[i]->has_key = RIAK_TRUE;
-            riak_binary_to_pb_copy(&(pblink[i]->key), link[i]->key);
+            riak_binary_copy_to_pb(&(pblink[i]->key), link[i]->key);
         }
         if (link[i]->has_tag) {
             pblink[i]->has_tag = RIAK_TRUE;
-            riak_binary_to_pb_copy(&(pblink[i]->tag), link[i]->tag);
+            riak_binary_copy_to_pb(&(pblink[i]->tag), link[i]->tag);
         }
     }
     // Finally assign the pointer to the list of link pointers
@@ -247,21 +247,21 @@ riak_links_copy_from_pb(riak_config  *cfg,
         memset(link[i], '\0', sizeof(riak_link));
         if (pblink[i]->has_bucket) {
             link[i]->has_bucket = RIAK_TRUE;
-            link[i]->bucket = riak_binary_populate_from_pb(cfg, &(pblink[i]->bucket));
+            link[i]->bucket = riak_binary_copy_from_pb(cfg, &(pblink[i]->bucket));
             if (link[i]->bucket == NULL) {
                 return ERIAK_OUT_OF_MEMORY;
             }
         }
         if (pblink[i]->has_key) {
             pblink[i]->has_key = RIAK_TRUE;
-            link[i]->key = riak_binary_populate_from_pb(cfg, &(pblink[i]->key));
+            link[i]->key = riak_binary_copy_from_pb(cfg, &(pblink[i]->key));
             if (link[i]->key == NULL) {
                 return ERIAK_OUT_OF_MEMORY;
             }
         }
         if (pblink[i]->has_tag) {
             pblink[i]->has_tag = RIAK_TRUE;
-            link[i]->tag = riak_binary_populate_from_pb(cfg, &(pblink[i]->tag));
+            link[i]->tag = riak_binary_copy_from_pb(cfg, &(pblink[i]->tag));
             if (link[i]->tag == NULL) {
                 return ERIAK_OUT_OF_MEMORY;
             }
@@ -376,18 +376,18 @@ riak_object_to_pb_copy(riak_config *cfg,
 
     rpb_content__init(to);
 
-    riak_binary_to_pb_copy(&(to->value), from->value);
+    riak_binary_copy_to_pb(&(to->value), from->value);
     if (from->has_charset) {
         to->has_charset = RIAK_TRUE;
-        riak_binary_to_pb_copy(&(to->charset), from->charset);
+        riak_binary_copy_to_pb(&(to->charset), from->charset);
     }
     if (from->has_content_encoding) {
         to->has_content_encoding = RIAK_TRUE;
-        riak_binary_to_pb_copy(&(to->content_encoding), from->encoding);
+        riak_binary_copy_to_pb(&(to->content_encoding), from->encoding);
     }
     if (from->has_content_type) {
         to->has_content_type = RIAK_TRUE;
-        riak_binary_to_pb_copy(&(to->content_type), from->content_type);
+        riak_binary_copy_to_pb(&(to->content_type), from->content_type);
     }
     if (from->has_deleted) {
         to->has_deleted = RIAK_TRUE;
@@ -403,7 +403,7 @@ riak_object_to_pb_copy(riak_config *cfg,
     }
     if (from->has_vtag) {
         to->has_vtag = RIAK_TRUE;
-        riak_binary_to_pb_copy(&(to->vtag), from->vtag);
+        riak_binary_copy_to_pb(&(to->vtag), from->vtag);
     }
 
     // Indexes
@@ -447,14 +447,14 @@ riak_object_new_from_pb(riak_config  *cfg,
     }
     riak_object *to = *target;
 
-    to->value = riak_binary_populate_from_pb(cfg, &(from->value));
+    to->value = riak_binary_copy_from_pb(cfg, &(from->value));
     if (to->value == NULL) {
         riak_free(cfg, target);
         return ERIAK_OUT_OF_MEMORY;
     }
     if (from->has_charset) {
         to->has_charset = RIAK_TRUE;
-        to->charset= riak_binary_populate_from_pb(cfg, &(from->charset));
+        to->charset= riak_binary_copy_from_pb(cfg, &(from->charset));
         if (to->charset == NULL) {
             riak_free(cfg, target);
             return ERIAK_OUT_OF_MEMORY;
@@ -462,7 +462,7 @@ riak_object_new_from_pb(riak_config  *cfg,
     }
     if (from->has_content_encoding) {
         to->has_content_encoding = RIAK_TRUE;
-        to->encoding = riak_binary_populate_from_pb(cfg, &(from->content_encoding));
+        to->encoding = riak_binary_copy_from_pb(cfg, &(from->content_encoding));
         if (to->encoding == NULL) {
             riak_free(cfg, target);
             return ERIAK_OUT_OF_MEMORY;
@@ -470,7 +470,7 @@ riak_object_new_from_pb(riak_config  *cfg,
     }
     if (from->has_content_type) {
         to->has_content_type = RIAK_TRUE;
-        to->content_type = riak_binary_populate_from_pb(cfg, &(from->content_type));
+        to->content_type = riak_binary_copy_from_pb(cfg, &(from->content_type));
         if (to->content_type == NULL) {
             riak_free(cfg, target);
             return ERIAK_OUT_OF_MEMORY;
@@ -490,7 +490,7 @@ riak_object_new_from_pb(riak_config  *cfg,
     }
     if (from->has_vtag) {
         to->has_vtag = RIAK_TRUE;
-        to->vtag = riak_binary_populate_from_pb(cfg, &(from->vtag));
+        to->vtag = riak_binary_copy_from_pb(cfg, &(from->vtag));
         if (to->vtag == NULL) {
             riak_free(cfg, target);
             return ERIAK_OUT_OF_MEMORY;

--- a/src/riak_operation.c
+++ b/src/riak_operation.c
@@ -101,7 +101,7 @@ riak_operation_set_bucket(riak_operation *rop,
                           riak_binary    *bucket) {
     riak_connection *cxn = riak_operation_get_connection(rop);
     riak_config     *cfg = riak_connection_get_config(cxn);
-    rop->request.bucket = riak_binary_deep_new(cfg, bucket);
+    rop->request.bucket = riak_binary_copy(cfg, bucket);
 }
 
 void
@@ -109,7 +109,7 @@ riak_operation_set_key(riak_operation *rop,
                        riak_binary    *key) {
     riak_connection *cxn = riak_operation_get_connection(rop);
     riak_config     *cfg = riak_connection_get_config(cxn);
-    rop->request.key = riak_binary_deep_new(cfg, key);
+    rop->request.key = riak_binary_copy(cfg, key);
 }
 
 void
@@ -117,7 +117,7 @@ riak_operation_set_index(riak_operation *rop,
                          riak_binary    *key) {
     riak_connection *cxn = riak_operation_get_connection(rop);
     riak_config     *cfg = riak_connection_get_config(cxn);
-    rop->request.index = riak_binary_deep_new(cfg, key);
+    rop->request.index = riak_binary_copy(cfg, key);
 }
 
 riak_binary*

--- a/test/cunit/include/test_binary.h
+++ b/test/cunit/include/test_binary.h
@@ -24,6 +24,9 @@ void
 test_build_binary();
 
 void
+test_build_binary_shallow();
+
+void
 test_build_binary_with_null();
 
 void

--- a/test/cunit/registry.c
+++ b/test/cunit/registry.c
@@ -61,6 +61,7 @@ main(int   argc,
     CU_pSuite operation_suite = CU_add_suite("riak_operation", init_fn, cleanup_fn);
     CU_pSuite messages_suite = CU_add_suite("riak_messages", init_fn, cleanup_fn);
     CU_ADD_TEST(binary_suite, test_build_binary);
+    CU_ADD_TEST(binary_suite, test_build_binary_shallow);
     CU_ADD_TEST(binary_suite, test_build_binary_with_null);
     CU_ADD_TEST(binary_suite, test_build_binary_from_pb);
     CU_ADD_TEST(binary_suite, test_build_binary_to_pb);

--- a/test/cunit/test_binary.c
+++ b/test/cunit/test_binary.c
@@ -55,8 +55,6 @@ test_build_binary_with_null() {
     CU_ASSERT_FATAL(bin != NULL)
     riak_int32_t  len = riak_binary_len(bin);
     CU_ASSERT_EQUAL(len,0);
-    riak_uint8_t *data = riak_binary_data(bin);
-    CU_ASSERT_EQUAL(data, NULL);
     riak_binary_free(cfg, &bin);
     CU_PASS("test_build_binary_with_null passed")
 }
@@ -68,7 +66,8 @@ test_build_binary_from_existing() {
     CU_ASSERT_FATAL(err == ERIAK_OK)
     riak_binary *bin = riak_binary_new(cfg, 6, (riak_uint8_t*)"abcdef");
     CU_ASSERT_FATAL(bin != NULL)
-    riak_binary *bin2 = riak_binary_populate(cfg, bin);
+    riak_binary *bin2 = riak_binary_copy(cfg, bin);
+    CU_ASSERT_FATAL(bin2 != NULL)
     riak_int32_t  len = riak_binary_len(bin2);
     CU_ASSERT_EQUAL(len,6);
     riak_uint8_t *data = riak_binary_data(bin2);
@@ -86,7 +85,7 @@ test_build_binary_from_pb() {
     ProtobufCBinaryData pb_bin;
     pb_bin.len  = 6;
     pb_bin.data = (riak_uint8_t *)"abcdef";
-    riak_binary *bin = riak_binary_populate_from_pb(cfg, &pb_bin);
+    riak_binary *bin = riak_binary_copy_from_pb(cfg, &pb_bin);
     CU_ASSERT_FATAL(bin != NULL)
     riak_int32_t len = riak_binary_len(bin);
     CU_ASSERT_EQUAL(len,6);
@@ -104,11 +103,10 @@ test_build_binary_to_pb() {
     ProtobufCBinaryData pb_bin;
     riak_binary *bin = riak_binary_new(cfg, 6, (riak_uint8_t*)"abcdef");
     CU_ASSERT_FATAL(bin != NULL)
-    err = riak_binary_to_pb_deep_copy(cfg, &pb_bin, bin);
+    riak_binary_copy_to_pb(&pb_bin, bin);
     CU_ASSERT_EQUAL(pb_bin.len,6);
     CU_ASSERT_EQUAL(memcmp(pb_bin.data, "abcdef", 6), 0);
     riak_binary_free(cfg, &bin);
-    riak_binary_deep_free_pb(cfg, &pb_bin);
     CU_PASS("test_build_binary_from_pb passed")
 }
 
@@ -117,7 +115,7 @@ test_binary_new_from_string() {
     riak_config *cfg;
     riak_error    err = riak_config_new_default(&cfg);
     CU_ASSERT_FATAL(err == ERIAK_OK)
-    riak_binary  *bin = riak_binary_new_from_string(cfg, "abcdef");
+    riak_binary  *bin = riak_binary_copy_from_string(cfg, "abcdef");
     CU_ASSERT_FATAL(bin != NULL)
     riak_int32_t  len = riak_binary_len(bin);
     CU_ASSERT_EQUAL(len,6);

--- a/test/cunit/test_binary.c
+++ b/test/cunit/test_binary.c
@@ -47,6 +47,32 @@ test_build_binary() {
 }
 
 void
+test_build_binary_shallow() {
+    riak_config *cfg;
+    riak_error    err = riak_config_new_default(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+    riak_uint8_t *ptr = (riak_uint8_t*)"abcdef";
+    riak_binary  *bin = riak_binary_new_shallow(cfg, 6, ptr);
+    CU_ASSERT_FATAL(bin != NULL)
+    riak_int32_t  len = riak_binary_len(bin);
+    CU_ASSERT_EQUAL(len,6)
+    riak_uint8_t *data = riak_binary_data(bin);
+    CU_ASSERT_EQUAL(memcmp(data, "abcdef", 6), 0)
+    // Should point the same memory
+    CU_ASSERT_EQUAL(data, ptr)
+    riak_binary_free(cfg, &bin);
+    riak_binary *shallow = riak_binary_new(cfg, 6, ptr);
+    bin = riak_binary_copy_shallow(cfg, shallow);
+    data = riak_binary_data(bin);
+    CU_ASSERT_EQUAL(data, ptr)
+    data = riak_binary_data(bin);
+    CU_ASSERT_EQUAL(data, ptr)
+    riak_binary_free(cfg, &bin);
+    riak_binary_free(cfg, &shallow);
+    CU_PASS("test_build_binary_shallow passed")
+}
+
+void
 test_build_binary_with_null() {
     riak_config *cfg;
     riak_error    err = riak_config_new_default(&cfg);


### PR DESCRIPTION
This struct and its supporting functions developed organically over the creation of the API.  It had two flavors: deep and shallow copies.  The naming was inconsistent and because sometimes pointers did not point to memory which it owned, the user had to be careful which version to call to free memory.

This refactor makes the interface much simpler and the data is copied by default.  I found though the refactoring exercise that there are places where a shallow-copied binary is probably more efficient.  A `managed` flag was added along the way, too, to determine who should free the payload.
