### PR TITLE
fix some segfaults while using riak_get()

### DIFF
--- a/src/internal/riak_utils-internal.h
+++ b/src/internal/riak_utils-internal.h
@@ -61,4 +61,16 @@ riak_array_realloc(riak_config *cfg,
                    riak_uint32_t oldnum,
                    riak_uint32_t newnum);
 
+/**
+ * @brief append a formatted string to a length-limited buffer
+ * @param target pointer to end of the buffer, which will be updated
+ * @param left_to_write to-be-updated available space
+ * @param format
+ */
+size_t
+riak_snprintf_cat(char **target,
+		  riak_uint32_t *left_to_write,
+		  const char *format,
+		  ...);
+
 #endif // _RIAK_UTILS_INTERNAL_H

--- a/src/messages/riak_get.c
+++ b/src/messages/riak_get.c
@@ -154,7 +154,7 @@ riak_print_get_response(riak_get_response *response,
                         char              *target,
                         riak_size_t        len) {
     riak_int32_t left_to_write = len;
-    riak_int32_t wrote;
+    riak_int32_t wrote = 0;
     riak_print_binary_hex("V-Clock", response->vclock, &target, &wrote, &left_to_write);
     riak_print_bool("Unmodified", response->unmodified, &target, &wrote, &left_to_write);
     riak_print_bool("Deleted", response->deleted, &target, &wrote, &left_to_write);
@@ -163,6 +163,10 @@ riak_print_get_response(riak_get_response *response,
     riak_uint32_t i;
     for(i = 0; (i < response->n_content) && (left_to_write > 0); i++) {
         wrote = riak_object_print(response->content[i], target, left_to_write);
+
+	if (wrote >= left_to_write)
+	  wrote = left_to_write - 1;
+
         left_to_write -= wrote;
         target += wrote;
     }

--- a/src/riak.c
+++ b/src/riak.c
@@ -461,6 +461,8 @@ riak_read(riak_operation *rop,
         // Are we done yet? If not, break out and wait for the next callback
         if (rop->position < rop->msglen) {
             riak_log_error(cxn, "%s","Partial message received");
+            if (!rop->response_cb) /* If the operation is not async, read again */
+              continue;
             return ERIAK_OK;
         }
         assert(rop->position == rop->msglen);


### PR DESCRIPTION
- make the "not sync" operation of riak_get() really not async, thus not returing a NULL rop->response for an ERRIAK_OK status
- fix some buffer overflows into functions called by riak_print_get_response()
