### PR TITLE
Couple 'o CUnit Integration Tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -121,9 +121,11 @@ riak_c_example_LDADD = \
 riak_c_example_DEPENDENCIES = libriak_c_client-0.5.la
 
 check_PROGRAMS = riak_c_cunit
-riak_c_cunit_SOURCES = 	test/cunit/registry.c \
+riak_c_cunit_SOURCES = test/cunit/test.c \
+			test/cunit/registry.c \
 			test/cunit/test_2index.c \
 			test/cunit/test_binary.c \
+			test/cunit/test_bucket_key_value.c \
 			test/cunit/test_bucketprops.c \
 			test/cunit/test_clientid.c \
 			test/cunit/test_config.c \
@@ -135,6 +137,7 @@ riak_c_cunit_SOURCES = 	test/cunit/registry.c \
 			test/cunit/test_listbuckets.c \
 			test/cunit/test_listkeys.c \
 			test/cunit/test_object.c \
+			test/cunit/test_ping.c \
 			test/cunit/test_put.c \
 			test/cunit/test_search.c \
 			test/cunit/test_serverinfo.c

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Doxygen generated docs located [here](http://basho.github.io/riak-c-client/globa
 * libevent-2.0.21
 * protobuf-2.5.0
 * protobuf-c-0.15
-* cunit
+* cunit-2.1-2
 * pkg-config
 * pthreads
 * doxygen (if you are building docs)
@@ -67,7 +67,7 @@ make install
 
 ```
 sudo apt-get update
-sudo apt-get install build-essential git automake libtool libcunit1-dev doxygen
+sudo apt-get install build-essential git automake libtool doxygen
 
 wget https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.gz
 tar fx protobuf-2.5.0.tar.gz
@@ -96,6 +96,14 @@ LD_LIBRARY_PATH=/usr/local/protobuf-2.5.0/lib:/usr/local/lib make check
 sudo make install
 cd ..
  
+wget http://sourceforge.net/projects/cunit/files/CUnit/2.1-2/CUnit-2.1-2-src.tar.bz2
+tar fx CUnit-2.1-2
+./configure
+make
+make check
+sudo make install
+cd ..
+
 git clone https://github.com/basho/riak-c-client
 cd riak-c-client
 ./autogen.sh

--- a/src/adapters/riak_libevent.h
+++ b/src/adapters/riak_libevent.h
@@ -56,9 +56,9 @@ riak_libevent_connection_cb(struct bufferevent *bev,
 #ifdef _RIAK_DEBUG
          struct evbuffer *ev_read  = bufferevent_get_input(bev);
          struct evbuffer *ev_write = bufferevent_get_output(bev);
-#endif
          riak_log_debug(cxn, "Closing because of %s [read event=%p, write event=%p]",
                  reason, (void*)ev_read, (void*)ev_write);
+#endif
          bufferevent_free(bev);
          event_base_loopexit(bufferevent_get_base(bev), NULL);
     } else if (events & BEV_EVENT_TIMEOUT) {

--- a/src/include/riak_error.h
+++ b/src/include/riak_error.h
@@ -42,6 +42,7 @@ typedef enum riak_error_enum {
     ERIAK_UNINITIALIZED,
     ERIAK_SERVER_ERROR,
     ERIAK_MESSAGE_FORMAT,
+    ERIAK_THREAD,
     ERIAK_LAST_ERRORNUM
 } riak_error;
 
@@ -61,6 +62,7 @@ static const char* errmsgs[] = {
     "Uninitialized Value",
     "An error was returned from the server",
     "Message Format Error",
+    "Threading Error",
     "SENTINEL FOR LAST ERROR MESSAGE"
 };
 #endif

--- a/test/cunit/include/test.h
+++ b/test/cunit/include/test.h
@@ -1,0 +1,158 @@
+/*********************************************************************
+ *
+ * test.h: Riak C Common Testing Utilities
+ *
+ * Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+ *
+ * This file is provided to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *********************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <string.h>
+#include "riak.h"
+#include "riak_async.h"
+#include "test_bucket_key_value.h"
+
+#ifndef _RIAK_C_TEST_H
+#define _RIAK_C_TEST_H
+
+#define RIAK_TEST_NUM_THREADS   20
+#define RIAK_TEST_BUCKET_PREFIX "riak_c_test_"
+
+#define RIAK_TEST_MAX_BUCKETS   50
+#define RIAK_TEST_MAX_KEYS      50
+
+#define RIAK_TEST_HOST          "RIAK_TEST_HOST"
+#define RIAK_TEST_PB_PORT       "RIAK_TEST_PB_PORT"
+
+
+/**
+ * @brief Set up testing environment
+ * @param cfg Returned Riak Configuration
+  * @returns Error Code
+ */
+riak_error
+test_setup(riak_config **cfg);
+
+/**
+ * @brief Connect to a live Riak cluster
+ * @param cfg Riak Configuration
+ * @param cxn Returned Riak Connection
+ * @returns Error Code
+ */
+riak_error
+test_connect(riak_config      *cfg,
+             riak_connection **cxn);
+
+/**
+ * @brief Disconnect from a Riak cluster
+ * @param cfg Riak Configuration
+ * @param cxn Riak Connection
+*/
+void
+test_disconnect(riak_config      *cfg,
+                riak_connection **cxn);
+
+/**
+ * @brief Clean up Testing environment
+ * @param cfg Riak Configuration
+ * @param cxn Riak Connection
+*/
+void
+test_cleanup(riak_config **cfg);
+
+typedef struct _test_async_connection {
+    riak_config       *cfg;
+    riak_connection   *cxn;
+    riak_operation    *rop;
+    riak_libevent     *rev;
+    struct event_base *base;
+} test_async_connection;
+
+typedef struct _test_async_args {
+    test_async_connection *conn;
+} test_async_pthread_args;
+
+typedef void*(*test_async_pthread_fun)(void*);
+
+/**
+ * @brief Set up asynchronous testing environment
+ * @param cfg Riak Configuration
+ * @param conn Returned Async Test Connection
+ * @returns Error Code
+ */
+riak_error
+test_async_connect(riak_config            *cfg,
+                   test_async_connection **conn);
+
+/**
+ * @brief Clean up asynchronous testing environment
+ * @param conn Async Test Connection
+ */
+void
+test_async_disconnect(test_async_connection **conn);
+
+/**
+ * @brief Build a random printable ASCII string
+ * @param cfg Riak Configuration
+ * @param len Length of generated string
+ * @returns Random ASCII string
+ */
+char*
+test_random_string(riak_config  *cfg,
+                   riak_uint32_t len);
+
+/**
+ * @brief Fire off the asynchronous thread
+ * @param cfg Riak Configuration
+ * @param f Thread function to run
+ * @param args Arguments passed to the thread with test_async_connection always being the first element
+ * @returns Error Code
+ */
+riak_error
+test_async_thread_runner(riak_config             *cfg,
+                         test_async_pthread_fun   f,
+                         test_async_pthread_args *args);
+
+/**
+ * @brief Queue up asynchronous message and fire event loop
+ * @oaram conn Testing Connection
+ * @returns Error Code
+ */
+riak_error
+test_async_send_message(test_async_connection *conn);
+
+/**
+ * @brief Throw lots of crap into Riak for testing
+ * @param cfg Riak Configuration
+ * @param cxn Riak Connection
+ * @param root Returned linked-list of Bucket/Key/Values
+ */
+riak_error
+test_load_db(riak_config            *cfg,
+             riak_connection        *cxn,
+             test_bucket_key_value **root);
+
+/**
+ * @brief Destroy all buckets starting with RIAK_TEST_BUCKET_PREFIX
+ * @param conn Test connection to the DB
+ */
+riak_error
+test_cleanup_db(riak_connection* cxn);
+
+#endif // _RIAK_C_TEST_H

--- a/test/cunit/include/test.h
+++ b/test/cunit/include/test.h
@@ -34,8 +34,10 @@
 #define RIAK_TEST_NUM_THREADS   10
 #define RIAK_TEST_BUCKET_PREFIX "riak_c_test_"
 
-#define RIAK_TEST_MAX_BUCKETS   50
-#define RIAK_TEST_MAX_KEYS      50
+#define RIAK_TEST_MAX_BUCKETS       50
+#define RIAK_TEST_MAX_KEYS          50
+#define RIAK_TEST_BUCKET_KEY_LEN    20
+#define RIAK_TEST_VALUE_LEN         200
 
 #define RIAK_TEST_HOST          "RIAK_TEST_HOST"
 #define RIAK_TEST_PB_PORT       "RIAK_TEST_PB_PORT"
@@ -44,7 +46,7 @@
 /**
  * @brief Set up testing environment
  * @param cfg Returned Riak Configuration
-  * @returns Error Code
+ * @returns Error Code
  */
 riak_error
 test_setup(riak_config **cfg);
@@ -82,6 +84,8 @@ typedef struct _test_async_connection {
     riak_operation    *rop;
     riak_libevent     *rev;
     struct event_base *base;
+    riak_error         err;     // Returned from callback
+    char               err_msg[1024]; // Optionally returned by callback
 } test_async_connection;
 
 typedef struct _test_async_pthread {

--- a/test/cunit/include/test.h
+++ b/test/cunit/include/test.h
@@ -31,7 +31,7 @@
 #ifndef _RIAK_C_TEST_H
 #define _RIAK_C_TEST_H
 
-#define RIAK_TEST_NUM_THREADS   20
+#define RIAK_TEST_NUM_THREADS   10
 #define RIAK_TEST_BUCKET_PREFIX "riak_c_test_"
 
 #define RIAK_TEST_MAX_BUCKETS   50
@@ -84,9 +84,12 @@ typedef struct _test_async_connection {
     struct event_base *base;
 } test_async_connection;
 
-typedef struct _test_async_args {
+typedef struct _test_async_pthread {
     test_async_connection *conn;
-} test_async_pthread_args;
+    pthread_t              tid;
+    void                  *result;
+    void                  *args;
+} test_async_pthread;
 
 typedef void*(*test_async_pthread_fun)(void*);
 
@@ -121,13 +124,13 @@ test_random_string(riak_config  *cfg,
  * @brief Fire off the asynchronous thread
  * @param cfg Riak Configuration
  * @param f Thread function to run
- * @param args Arguments passed to the thread with test_async_connection always being the first element
+ * @param args Arguments passed to the thread
  * @returns Error Code
  */
 riak_error
 test_async_thread_runner(riak_config             *cfg,
                          test_async_pthread_fun   f,
-                         test_async_pthread_args *args);
+                         void                    *args);
 
 /**
  * @brief Queue up asynchronous message and fire event loop

--- a/test/cunit/include/test_bucket_key_value.h
+++ b/test/cunit/include/test_bucket_key_value.h
@@ -1,0 +1,57 @@
+/*********************************************************************
+ *
+ * test_bucket_key_value.h: Riak C Bucket, Key, Value Tuple
+ *
+ * Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+ *
+ * This file is provided to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *********************************************************************/
+
+#ifndef _TEST_BUCKET_KEY_VALUE_
+#define _TEST_BUCKET_KEY_VALUE_
+
+typedef struct _test_bucket_key_value {
+    riak_binary *bucket;
+    riak_binary *key;
+    riak_binary *value;
+    struct _test_bucket_key_value *next;
+} test_bucket_key_value;
+
+/**
+ * @brief Add a simple record to the list of Bucket/Key/Values
+ * @param cfg Riak Configuration
+ * @param root Updated first link in linked list of BKVs
+ * @param bucket Name of bucket
+ * @param key Name of key
+ * @param value Value
+ * @returns Error Code
+ */
+riak_error
+test_bkv_add(riak_config            *cfg,
+             test_bucket_key_value **root,
+             riak_binary            *bucket,
+             riak_binary            *key,
+             riak_binary            *value);
+
+/**
+ * @brief Frees the entire linked list of Bucket/Key/Values
+ * @param cfg Riak Configuration
+ * @param root First link in linked list of BKVs
+ */
+void
+test_bkv_free(riak_config *cfg,
+              test_bucket_key_value **root);
+#endif //_TEST_BUCKET_KEY_VALUE_

--- a/test/cunit/include/test_listkeys.h
+++ b/test/cunit/include/test_listkeys.h
@@ -22,3 +22,9 @@
 
 void
 test_listkeys_response_decode();
+
+void
+test_integration_listkeys();
+
+void
+test_integration_async_listkeys();

--- a/test/cunit/include/test_ping.h
+++ b/test/cunit/include/test_ping.h
@@ -1,6 +1,6 @@
 /*********************************************************************
  *
- * test_listbuckets.h:  Riak C Unit testing for List Buckets Message
+ * test_ping.h:  Riak C Unit testing for Ping Message
  *
  * Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
  *
@@ -21,10 +21,7 @@
  *********************************************************************/
 
 void
-test_listbuckets_response_decode();
+test_integration_ping();
 
 void
-test_integration_listbuckets();
-
-void
-test_integration_async_listbuckets();
+test_integration_async_ping();

--- a/test/cunit/include/test_serverinfo.h
+++ b/test/cunit/include/test_serverinfo.h
@@ -28,3 +28,9 @@ test_server_info_decode_good_response();
 
 void
 test_server_info_decode_bad_response();
+
+void
+test_integration_server_info();
+
+void
+test_integration_async_server_info();

--- a/test/cunit/registry.c
+++ b/test/cunit/registry.c
@@ -37,6 +37,7 @@
 #include "test_clientid.h"
 #include "test_delete.h"
 #include "test_get.h"
+#include "test_ping.h"
 #include "test_put.h"
 #include "test_listbuckets.h"
 #include "test_listkeys.h"
@@ -61,6 +62,7 @@ main(int   argc,
     CU_pSuite connection_suite = CU_add_suite("riak_connection", init_fn, cleanup_fn);
     CU_pSuite operation_suite = CU_add_suite("riak_operation", init_fn, cleanup_fn);
     CU_pSuite messages_suite = CU_add_suite("riak_messages", init_fn, cleanup_fn);
+    CU_pSuite integration_suite = CU_add_suite("integration_suite", init_fn, cleanup_fn);
     CU_ADD_TEST(binary_suite, test_build_binary);
     CU_ADD_TEST(binary_suite, test_build_binary_shallow);
     CU_ADD_TEST(binary_suite, test_build_binary_with_null);
@@ -146,13 +148,20 @@ main(int   argc,
     CU_ADD_TEST(messages_suite, test_riak_object_links);
     CU_ADD_TEST(messages_suite, test_riak_object_usermeta);
     CU_ADD_TEST(messages_suite, test_riak_object_indexes);
-
-
+    CU_ADD_TEST(integration_suite, test_integration_ping);
+    CU_ADD_TEST(integration_suite, test_integration_async_ping);
+    CU_ADD_TEST(integration_suite, test_integration_server_info);
+    CU_ADD_TEST(integration_suite, test_integration_async_server_info);
+    CU_ADD_TEST(integration_suite, test_integration_listbuckets);
+    CU_ADD_TEST(integration_suite, test_integration_async_listbuckets);
+    CU_ADD_TEST(integration_suite, test_integration_listkeys);
+    CU_ADD_TEST(integration_suite, test_integration_async_listkeys);
 
     // Run all tests using the CUnit Basic interface
     CU_basic_set_mode(CU_BRM_VERBOSE);
     CU_basic_run_tests();
 
-    void CU_cleanup_registry();
-    return 0;
+    int failures = CU_get_number_of_failures();
+    CU_cleanup_registry();
+    return failures;
 }

--- a/test/cunit/registry.c
+++ b/test/cunit/registry.c
@@ -28,6 +28,7 @@
 #include <CUnit/Automated.h>
 #include <CUnit/Basic.h>
 #include "riak.h"
+#include "test.h"
 #include "test_2index.h"
 #include "test_binary.h"
 #include "test_config.h"
@@ -50,6 +51,14 @@ int
 main(int   argc,
      char *argv[])
 {
+    event_enable_debug_mode();
+    evthread_enable_lock_debuging();
+    int result = evthread_use_pthreads();
+    if (result < 0) {
+        fprintf(stderr, "Could not use pthreads for libevent\n");
+        return ERIAK_EVENT;
+    }
+
     CU_ErrorCode cuerr = CU_initialize_registry();
     if (cuerr != CUE_SUCCESS) {
         fprintf(stderr, "Could not initialize cuint testing registry\n");

--- a/test/cunit/test.c
+++ b/test/cunit/test.c
@@ -1,0 +1,333 @@
+/*********************************************************************
+ *
+ * test.c: Riak C Common Testing Utilities
+ *
+ * Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+ *
+ * This file is provided to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *********************************************************************/
+
+#include <event2/dns.h>
+#include <event2/bufferevent.h>
+#include <event2/buffer.h>
+#include <event2/util.h>
+#include <event2/event.h>
+#include <event2/thread.h>
+#include <pthread.h>
+#include "test.h"
+#include "riak_async.h"
+#include "../../src/adapters/riak_libevent.h"
+
+riak_error
+test_setup(riak_config **cfg) {
+    return riak_config_new_default(cfg);
+}
+
+riak_error
+test_connect(riak_config      *cfg,
+             riak_connection **cxn) {
+    char *hostname = (char*)"localhost";
+    char *pb_port  = (char*)"8087";
+
+    char *env_host = getenv(RIAK_TEST_HOST);
+    char *env_port = getenv(RIAK_TEST_PB_PORT);
+
+    if (env_host) {
+        hostname = env_host;
+    }
+    if (env_port) {
+        pb_port = env_port;
+    }
+
+    return riak_connection_new(cfg, cxn, hostname, pb_port, NULL);
+}
+
+void
+test_disconnect(riak_config      *cfg,
+                riak_connection **cxn) {
+    riak_connection_free(cxn);
+}
+
+void
+test_cleanup(riak_config **cfg) {
+    riak_config_free(cfg);
+}
+
+void
+riak_test_error_cb(void *resp,
+                   void *ptr) {
+    riak_operation *rop = (riak_operation*)ptr;
+    char message[1024];
+    riak_server_error *error = riak_operation_get_server_error(rop);
+    if (error) {
+        riak_binary_print(riak_server_error_get_errmsg(error), message, sizeof(message));
+        fprintf(stderr, "ERROR: %s\n", message);
+    }
+    //TODO: How do we bail from this callback?
+}
+
+riak_error
+test_async_connect(riak_config            *cfg,
+                   test_async_connection **conn_out) {
+    evthread_enable_lock_debuging();
+    int result = evthread_use_pthreads();
+    if (result < 0) {
+        fprintf(stderr, "Could not use pthreads for libevent\n");
+        return ERIAK_EVENT;
+    }
+
+    *conn_out = riak_config_clean_allocate(cfg, sizeof(test_async_connection));
+    if (*conn_out == NULL) {
+        return ERIAK_OUT_OF_MEMORY;
+    }
+    test_async_connection *conn = *conn_out;
+    conn->cfg = cfg;
+    riak_error err = test_connect(cfg, &(conn->cxn));
+    if (err) {
+        fprintf(stderr, "Could not connect to Riak\n");
+        return err;
+    }
+    err = riak_operation_new(conn->cxn, &(conn->rop), NULL, NULL, NULL);
+    if (err) {
+        fprintf(stderr, "Could not allocate an operation\n");
+        return err;
+    }
+    // Create a new event base for each thread
+    conn->base = event_base_new();
+    if (conn->base == NULL) {
+        fprintf(stderr, "Could not allocate a Libevent base\n");
+        return ERIAK_EVENT;
+    }
+    result = evthread_make_base_notifiable(conn->base);
+    if (result) {
+        fprintf(stderr, "Could not set libevent base to be notifiable\n");
+        return ERIAK_EVENT;
+    }
+
+    err = riak_libevent_new(&(conn->rev), conn->rop, conn->base);
+    if (err) {
+        fprintf(stderr, "Could not allocate a new libevent\n");
+        return err;
+    }
+    riak_operation_set_error_cb(conn->rop, riak_test_error_cb);
+    riak_operation_set_cb_data(conn->rop, conn->rop);
+
+    return err;
+}
+
+void
+test_async_disconnect(test_async_connection **conn_out) {
+    test_async_connection *conn = *conn_out;
+    riak_operation_free(&(conn->rop));
+    riak_connection_free(&(conn->cxn));
+    //TODO: Fix this freeing of the event
+    //riak_libevent_free(conn->cfg, &(conn->rev));
+    event_base_free(conn->base);
+    conn->base = NULL;
+    riak_free(conn->cfg, conn_out);
+}
+
+
+riak_error
+test_async_thread_runner(riak_config             *cfg,
+                         test_async_pthread_fun   f,
+                         test_async_pthread_args *args) {
+    test_async_connection* conn[RIAK_TEST_NUM_THREADS];
+    pthread_t tid[RIAK_TEST_NUM_THREADS];
+    void *result[RIAK_TEST_NUM_THREADS];
+    for(int i = 0; i < sizeof(conn)/sizeof(test_async_connection*); i++) {
+        riak_error err = test_async_connect(cfg, &(conn[i]));
+        if (err) {
+            return err;
+        }
+
+        args->conn = conn[i];
+        int status = pthread_create(&tid[i], NULL, f, args);
+        if (status != 0) {
+            return ERIAK_THREAD;
+        }
+        fprintf(stderr, "Spawned TID %llu\n", (riak_uint64_t)tid[i]);
+    }
+
+    for(int i = 0; i < sizeof(result)/sizeof(void*); i++) {
+        int status = pthread_join(tid[i], &result[i]);
+        if (status != 0) {
+            return ERIAK_THREAD;
+        }
+        if (result[i] != NULL) {
+            fprintf(stderr, "THREAD ERROR: %s\n", (char*)result[i]);
+        }
+    }
+    for(int i = 0; i < sizeof(conn)/sizeof(test_async_connection*); i++) {
+        test_async_disconnect(&(conn[i]));
+    }
+    return ERIAK_OK;
+}
+
+char*
+test_random_string(riak_config  *cfg,
+                   riak_uint32_t len) {
+    char *result = riak_config_clean_allocate(cfg, len+1);
+    if (result != NULL) {
+        int i;
+        for(i = 0; i< len; i++) {
+            result[i] = (char)(32+(rand() % (127-32)));
+        }
+        result[i] = '\0';
+    }
+    return result;
+}
+
+
+riak_error
+test_load_db(riak_config            *cfg,
+             riak_connection        *cxn,
+             test_bucket_key_value **root) {
+    for (int b = 0; b < RIAK_TEST_MAX_BUCKETS; b++) {
+        char *suffix = test_random_string(cfg, 20);
+        if (suffix == NULL) {
+            return ERIAK_OUT_OF_MEMORY;
+        }
+        char bucket[128];
+        snprintf(bucket, sizeof(bucket), "%s%s", RIAK_TEST_BUCKET_PREFIX, suffix);
+        for(int k = 0; k < RIAK_TEST_MAX_KEYS; k++) {
+            char *key = test_random_string(cfg, 20);
+            if (key == NULL) {
+                return ERIAK_OUT_OF_MEMORY;
+            }
+            char *value = test_random_string(cfg, 200);
+            if (value == NULL) {
+                return ERIAK_OUT_OF_MEMORY;
+            }
+            riak_object *obj = riak_object_new(cfg);
+            if (obj == NULL) {
+                return ERIAK_OUT_OF_MEMORY;
+            }
+            riak_binary *bucket_bin = riak_binary_copy_from_string(cfg, bucket);
+            if (bucket_bin == NULL) {
+                return ERIAK_OUT_OF_MEMORY;
+            }
+            riak_error err = riak_object_set_bucket(cfg, obj, bucket_bin);
+            if (err) {
+                return err;
+            }
+            riak_binary *key_bin = riak_binary_copy_from_string(cfg, key);
+            if (key_bin == NULL) {
+                return ERIAK_OUT_OF_MEMORY;
+            }
+            err = riak_object_set_key(cfg, obj, key_bin);
+            if (err) {
+                return err;
+            }
+            riak_binary *value_bin = riak_binary_copy_from_string(cfg, value);
+            if (value_bin == NULL) {
+                return ERIAK_OUT_OF_MEMORY;
+            }
+            err = riak_object_set_value(cfg, obj, value_bin);
+            if (err) {
+                return err;
+            }
+            riak_put_response *response = NULL;
+            err = test_bkv_add(cfg, root, bucket_bin, key_bin, value_bin);
+            //fprintf(stderr, "%s\t%s\t%s\n", bucket, key, value);
+            err = riak_put(cxn, obj, NULL, &response);
+            if (err) {
+                return err;
+            }
+            riak_put_response_free(cfg, &response);
+            /*
+             * These are now freed in test_bkv_free()
+             *
+             * riak_binary_free(cfg, &bucket_bin);
+             * riak_binary_free(cfg, &key_bin);
+             * riak_binary_free(cfg, &value_bin);
+             */
+            riak_object_free(cfg, &obj);
+        }
+    }
+    return ERIAK_OK;
+}
+
+riak_error
+test_cleanup_db(riak_connection* cxn) {
+    // Bail if there is no connection
+    if (cxn == NULL) return ERIAK_CONNECT;
+
+    const int prefixlen = strlen(RIAK_TEST_BUCKET_PREFIX);
+    riak_listbuckets_response *response = NULL;
+    riak_listbuckets(cxn, &response);
+    riak_uint32_t num_buckets = riak_listbuckets_get_n_buckets(response);
+    riak_binary **buckets = riak_listbuckets_get_buckets(response);
+    if (buckets == NULL) {
+        return ERIAK_OUT_OF_RANGE;
+    }
+    riak_error err = ERIAK_OK;
+    for(int b = 0; b < num_buckets; b++) {
+        riak_binary* bucket = buckets[b];
+        if (riak_binary_len(bucket) < prefixlen) continue;
+        // Does the bucket match the prefix? If so, start nuking
+        if (memcmp(riak_binary_data(bucket), RIAK_TEST_BUCKET_PREFIX, prefixlen) == 0) {
+            riak_listkeys_response *response;
+            err = riak_listkeys(cxn, bucket, 0, &response);
+            if (err) {
+                return err;
+            }
+            riak_uint32_t num_keys = riak_listkeys_get_n_keys(response);
+            riak_binary **keys = riak_listkeys_get_keys(response);
+            if (keys == NULL) {
+                return ERIAK_OUT_OF_RANGE;
+            }
+            for(int k = 0; k < num_keys; k++) {
+                riak_binary *key = keys[k];
+                //fprintf(stderr, "DEL %s\t%s\n", riak_binary_data(bucket), riak_binary_data(key));
+                err = riak_delete(cxn, bucket, key, NULL);
+                if (err) {
+                    return err;
+                }
+            }
+        }
+    }
+    return ERIAK_OK;
+}
+
+int
+test_async_event_loop(test_async_connection *conn) {
+    fprintf(stderr, "Event Loop on TID %llu\n", (riak_uint64_t)pthread_self());
+    return event_base_dispatch(conn->base);
+}
+
+riak_error
+test_async_send_message(test_async_connection *conn) {
+    fprintf(stderr, "Event Send on TID %llu\n", (riak_uint64_t)pthread_self());
+    riak_error err = riak_libevent_send(conn->rop, conn->rev);
+    if (err == ERIAK_OK) {
+        int result = test_async_event_loop(conn);
+        fprintf(stderr, "Event Loop on TID %llu returned %d\n", (riak_uint64_t)pthread_self(), result);
+        switch(result) {
+        case -1:
+            err = ERIAK_EVENT;
+            break;
+        case 1:
+            //err = ERIAK_NO_EVENT;
+            break;
+        default:
+            break;
+        }
+    }
+    return err;
+}
+
+

--- a/test/cunit/test.c
+++ b/test/cunit/test.c
@@ -126,8 +126,7 @@ test_async_disconnect(test_async_connection **conn_out) {
     test_async_connection *conn = *conn_out;
     riak_operation_free(&(conn->rop));
     riak_connection_free(&(conn->cxn));
-    //TODO: Fix this freeing of the event
-    //riak_libevent_free(conn->cfg, &(conn->rev));
+    riak_libevent_free(conn->cfg, &(conn->rev));
     event_base_free(conn->base);
     conn->base = NULL;
     riak_free(conn->cfg, conn_out);

--- a/test/cunit/test_binary.c
+++ b/test/cunit/test_binary.c
@@ -61,10 +61,8 @@ test_build_binary_shallow() {
     // Should point the same memory
     CU_ASSERT_EQUAL(data, ptr)
     riak_binary_free(cfg, &bin);
-    riak_binary *shallow = riak_binary_new(cfg, 6, ptr);
+    riak_binary *shallow = riak_binary_new_shallow(cfg, 6, ptr);
     bin = riak_binary_copy_shallow(cfg, shallow);
-    data = riak_binary_data(bin);
-    CU_ASSERT_EQUAL(data, ptr)
     data = riak_binary_data(bin);
     CU_ASSERT_EQUAL(data, ptr)
     riak_binary_free(cfg, &bin);

--- a/test/cunit/test_bucket_key_value.c
+++ b/test/cunit/test_bucket_key_value.c
@@ -1,0 +1,62 @@
+/*********************************************************************
+ *
+ * test_bucket_key_value.c: Riak C Bucket, Key, Value Tuple
+ *
+ * Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+ *
+ * This file is provided to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *********************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <string.h>
+#include "test.h"
+
+riak_error
+test_bkv_add(riak_config            *cfg,
+             test_bucket_key_value **root,
+             riak_binary            *bucket,
+             riak_binary            *key,
+             riak_binary            *value) {
+
+    test_bucket_key_value *node = riak_config_clean_allocate(cfg, sizeof(test_bucket_key_value));
+    if (node == NULL) {
+        return ERIAK_OUT_OF_MEMORY;
+    }
+    node->next = *root;
+    node->bucket = bucket;
+    node->key = key;
+    node->value = value;
+    *root = node;
+
+    return ERIAK_OK;
+}
+
+void
+test_bkv_free(riak_config *cfg,
+              test_bucket_key_value **root) {
+    test_bucket_key_value *node = *root;
+    while (node != NULL) {
+        riak_binary_free(cfg, &(node->bucket));
+        riak_binary_free(cfg, &(node->key));
+        riak_binary_free(cfg, &(node->value));
+        test_bucket_key_value *next = node->next;
+        riak_free(cfg, &node);
+        node = next;
+    }
+    *root = NULL;
+ }

--- a/test/cunit/test_listbuckets.c
+++ b/test/cunit/test_listbuckets.c
@@ -30,6 +30,7 @@
 #include "riak.h"
 #include "riak_messages-internal.h"
 #include "riak_operation-internal.h"
+#include "test.h"
 
 void
 test_listbuckets_response_decode() {
@@ -72,4 +73,89 @@ test_listbuckets_response_decode() {
     riak_listbuckets_response_free(cfg, &response);
     riak_config_free(&cfg);
     CU_PASS("test_listbuckets_response_decode passed")
+}
+
+void
+test_integration_listbuckets() {
+    riak_config     *cfg;
+    riak_connection *cxn = NULL;
+
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    err = test_connect(cfg, &cxn);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    test_bucket_key_value *db = NULL;
+    err = test_load_db(cfg, cxn, &db);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    riak_listbuckets_response *response = NULL;
+    err = riak_listbuckets(cxn, &response);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    char output[10240];
+    riak_listbuckets_response_print(response, output, sizeof(output));
+    fprintf(stderr, "%s", output);
+    riak_listbuckets_response_free(cfg, &response);
+
+    test_cleanup_db(cxn);
+    test_disconnect(cfg, &cxn);
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_listbuckets passed")
+}
+
+void
+test_listbuckets_async_cb(riak_listbuckets_response *response,
+                      void                      *ptr) {
+    riak_operation  *rop = (riak_operation*)ptr;
+    riak_connection *cxn = riak_operation_get_connection(rop);
+    riak_config     *cfg = riak_connection_get_config(cxn);
+    char output[10240];
+    riak_listbuckets_response_print(response, output, sizeof(output));
+    fprintf(stderr, "%s", output);
+    riak_listbuckets_response_free(cfg, &response);
+}
+
+/**
+ * @brief Encode and Send a List Buckets request
+ * @param args Parameters required to create List Buckets request
+ */
+void*
+test_listbuckets_async_thread(void *ptr) {
+    // Make thread-local copy
+    test_async_pthread_args args;
+    memcpy(&args, ptr, sizeof(test_async_pthread_args));
+    test_async_connection *conn = args.conn;
+    riak_error err = riak_async_register_listbuckets(conn->rop, (riak_response_callback)test_listbuckets_async_cb);
+    if (err) {
+        return (void*)riak_strerror(err);
+    }
+    err = test_async_send_message(conn);
+    if (err) {
+        return (void*)"Could not send request";
+    }
+    return NULL;
+}
+
+void
+test_integration_async_listbuckets() {
+    riak_config           *cfg;
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    riak_connection *cxn = NULL;
+    err = test_connect(cfg, &cxn);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+    test_bucket_key_value *db = NULL;
+    err = test_load_db(cfg, cxn, &db);
+
+    test_async_pthread_args args;
+    err = test_async_thread_runner(cfg, test_listbuckets_async_thread, &args);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    test_cleanup_db(cxn);
+    test_disconnect(cfg, &cxn);
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_async_listbuckets passed")
 }

--- a/test/cunit/test_listbuckets.c
+++ b/test/cunit/test_listbuckets.c
@@ -123,10 +123,8 @@ test_listbuckets_async_cb(riak_listbuckets_response *response,
  */
 void*
 test_listbuckets_async_thread(void *ptr) {
-    // Make thread-local copy
-    test_async_pthread_args args;
-    memcpy(&args, ptr, sizeof(test_async_pthread_args));
-    test_async_connection *conn = args.conn;
+    test_async_pthread *state = (test_async_pthread*)ptr;
+    test_async_connection *conn = state->conn;
     riak_error err = riak_async_register_listbuckets(conn->rop, (riak_response_callback)test_listbuckets_async_cb);
     if (err) {
         return (void*)riak_strerror(err);
@@ -150,8 +148,7 @@ test_integration_async_listbuckets() {
     test_bucket_key_value *db = NULL;
     err = test_load_db(cfg, cxn, &db);
 
-    test_async_pthread_args args;
-    err = test_async_thread_runner(cfg, test_listbuckets_async_thread, &args);
+    err = test_async_thread_runner(cfg, test_listbuckets_async_thread, NULL);
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
     test_cleanup_db(cxn);

--- a/test/cunit/test_listkeys.c
+++ b/test/cunit/test_listkeys.c
@@ -108,13 +108,16 @@ test_integration_listkeys() {
 void
 test_listkeys_async_cb(riak_listkeys_response *response,
                        void                   *ptr) {
-    riak_operation  *rop = (riak_operation*)ptr;
-    riak_connection *cxn = riak_operation_get_connection(rop);
-    riak_config     *cfg = riak_connection_get_config(cxn);
+    test_async_connection *conn = (test_async_connection*)ptr;
     char output[10240];
     riak_listkeys_response_print(response, output, sizeof(output));
     fprintf(stderr, "%s", output);
-    riak_listkeys_response_free(cfg, &response);
+    riak_uint32_t num = riak_listkeys_get_n_keys(response);
+    if (num < RIAK_TEST_MAX_BUCKETS) {
+        conn->err = ERIAK_OUT_OF_RANGE;
+        snprintf(conn->err_msg, sizeof(conn->err_msg), "Only %ul keys were returned", num);
+    }
+    riak_listkeys_response_free(conn->cfg, &response);
 }
 
 typedef struct _test_async_pthread_listkey_args {

--- a/test/cunit/test_listkeys.c
+++ b/test/cunit/test_listkeys.c
@@ -30,6 +30,7 @@
 #include "riak.h"
 #include "riak_messages-internal.h"
 #include "riak_operation-internal.h"
+#include "test.h"
 
 void
 test_listkeys_response_decode() {
@@ -70,4 +71,99 @@ test_listkeys_response_decode() {
     riak_listkeys_response_free(cfg, &response);
     riak_config_free(&cfg);
     CU_PASS("test_liskeys_response_decode passed")
+}
+
+void
+test_integration_listkeys() {
+    riak_config     *cfg;
+    riak_connection *cxn = NULL;
+
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    err = test_connect(cfg, &cxn);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    test_bucket_key_value *db = NULL;
+    err = test_load_db(cfg, cxn, &db);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    riak_listkeys_response *response = NULL;
+    err = riak_listkeys(cxn, db->bucket, 5000, &response);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+    CU_ASSERT_EQUAL(response->n_keys, 50)
+
+    char output[10240];
+    riak_listkeys_response_print(response, output, sizeof(output));
+    fprintf(stderr, "%s", output);
+    riak_listkeys_response_free(cfg, &response);
+
+    test_bkv_free(cfg, &db);
+    test_cleanup_db(cxn);
+    test_disconnect(cfg, &cxn);
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_listkeys passed")
+}
+
+void
+test_listkeys_async_cb(riak_listkeys_response *response,
+                       void                   *ptr) {
+    riak_operation  *rop = (riak_operation*)ptr;
+    riak_connection *cxn = riak_operation_get_connection(rop);
+    riak_config     *cfg = riak_connection_get_config(cxn);
+    char output[10240];
+    riak_listkeys_response_print(response, output, sizeof(output));
+    fprintf(stderr, "%s", output);
+    riak_listkeys_response_free(cfg, &response);
+}
+
+typedef struct _test_async_pthread_listkey_args {
+    test_async_connection  *conn;  // MUST BE FIRST
+    riak_binary            *bucket;
+    riak_uint32_t           timeout;
+} test_async_pthread_listkey_args;
+
+/**
+ * @brief Encode and Send a List Buckets request
+ * @param args Parameters required to create List Buckets request
+ */
+void*
+test_listkeys_async_thread(void *ptr) {
+    // Make thread-local copy
+    test_async_pthread_listkey_args args;
+    memcpy(&args, ptr, sizeof(test_async_pthread_listkey_args));
+    test_async_connection *conn = args.conn;
+    riak_error err = riak_async_register_listkeys(conn->rop, args.bucket, args.timeout, (riak_response_callback)test_listkeys_async_cb);
+    if (err) {
+        return (void*)riak_strerror(err);
+    }
+    err = test_async_send_message(conn);
+    if (err) {
+        return (void*)"Could not send request";
+    }
+    return NULL;
+}
+
+void
+test_integration_async_listkeys() {
+    riak_config           *cfg;
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    riak_connection *cxn = NULL;
+    err = test_connect(cfg, &cxn);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+    test_bucket_key_value *db = NULL;
+    err = test_load_db(cfg, cxn, &db);
+
+    test_async_pthread_listkey_args args;
+    args.bucket = db->bucket;  // Just pick a random bucket
+    args.timeout = 5000;
+    err = test_async_thread_runner(cfg, test_listkeys_async_thread, (test_async_pthread_args*)&args);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    test_cleanup_db(cxn);
+    test_disconnect(cfg, &cxn);
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_async_listkeys passed")
 }

--- a/test/cunit/test_ping.c
+++ b/test/cunit/test_ping.c
@@ -72,10 +72,8 @@ test_ping_async_cb(riak_ping_response *response,
  */
 void*
 test_ping_async_thread(void *ptr) {
-    // Make thread-local copy
-    test_async_pthread_args args;
-    memcpy(&args, ptr, sizeof(test_async_pthread_args));
-    test_async_connection *conn = args.conn;
+    test_async_pthread *state = (test_async_pthread*)ptr;
+    test_async_connection *conn = state->conn;
     riak_error err = riak_async_register_ping(conn->rop, (riak_response_callback)test_ping_async_cb);
     if (err) {
         return (void*)riak_strerror(err);
@@ -93,8 +91,7 @@ test_integration_async_ping() {
     riak_error err = test_setup(&cfg);
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
-    test_async_pthread_args args;
-    err = test_async_thread_runner(cfg, test_ping_async_thread, &args);
+    err = test_async_thread_runner(cfg, test_ping_async_thread, NULL);
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
     test_cleanup(&cfg);

--- a/test/cunit/test_ping.c
+++ b/test/cunit/test_ping.c
@@ -1,0 +1,102 @@
+/*********************************************************************
+ *
+ * test_ping.c: Riak C Integration testing for Ping message
+ *
+ * Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+ *
+ * This file is provided to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *********************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <string.h>
+#include <CUnit/CUnit.h>
+#include <CUnit/Automated.h>
+#include <CUnit/Basic.h>
+#include "riak.h"
+#include "riak_messages-internal.h"
+#include "riak_operation-internal.h"
+#include "test.h"
+
+void
+test_integration_ping() {
+    riak_config     *cfg;
+    riak_connection *cxn = NULL;
+
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    err = test_connect(cfg, &cxn);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    err = riak_ping(cxn);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    test_disconnect(cfg, &cxn);
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_ping passed")
+}
+
+/**
+ * @brief Callback for Ping message
+ * @param response Ping response
+ * @parm ptr Riak Operation
+ */
+void
+test_ping_async_cb(riak_ping_response *response,
+                  void               *ptr) {
+    riak_operation   *rop = (riak_operation*)ptr;
+    riak_connection  *cxn = riak_operation_get_connection(rop);
+    riak_config      *cfg = riak_connection_get_config(cxn);
+    riak_log_notice(cxn, "%s", "Asynchronous PONG");
+    riak_free_ping_response(cfg, &response);
+}
+
+/**
+ * @brief Encode and Send a Ping request
+ * @param args Parameters required to create Ping request
+ */
+void*
+test_ping_async_thread(void *ptr) {
+    // Make thread-local copy
+    test_async_pthread_args args;
+    memcpy(&args, ptr, sizeof(test_async_pthread_args));
+    test_async_connection *conn = args.conn;
+    riak_error err = riak_async_register_ping(conn->rop, (riak_response_callback)test_ping_async_cb);
+    if (err) {
+        return (void*)riak_strerror(err);
+    }
+    err = test_async_send_message(conn);
+    if (err) {
+        return (void*)"Could not send request";
+    }
+    return NULL;
+}
+
+void
+test_integration_async_ping() {
+    riak_config           *cfg;
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    test_async_pthread_args args;
+    err = test_async_thread_runner(cfg, test_ping_async_thread, &args);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_async_ping passed")
+}

--- a/test/cunit/test_ping.c
+++ b/test/cunit/test_ping.c
@@ -58,12 +58,10 @@ test_integration_ping() {
  */
 void
 test_ping_async_cb(riak_ping_response *response,
-                  void               *ptr) {
-    riak_operation   *rop = (riak_operation*)ptr;
-    riak_connection  *cxn = riak_operation_get_connection(rop);
-    riak_config      *cfg = riak_connection_get_config(cxn);
-    riak_log_notice(cxn, "%s", "Asynchronous PONG");
-    riak_free_ping_response(cfg, &response);
+                   void               *ptr) {
+    test_async_connection *conn = (test_async_connection*)ptr;
+    riak_log_notice(conn->cxn, "%s", "Asynchronous PONG");
+    riak_free_ping_response(conn->cfg, &response);
 }
 
 /**

--- a/test/cunit/test_serverinfo.c
+++ b/test/cunit/test_serverinfo.c
@@ -153,13 +153,11 @@ test_integration_server_info() {
 void
 test_serverinfo_async_cb(riak_serverinfo_response *response,
                          void                     *ptr) {
-    riak_operation   *rop = (riak_operation*)ptr;
-    riak_connection  *cxn = riak_operation_get_connection(rop);
-    riak_config      *cfg = riak_connection_get_config(cxn);
+    test_async_connection *conn = (test_async_connection*)ptr;
     char buffer[1024];
     riak_serverinfo_response_print(response, buffer, sizeof(buffer));
     fprintf(stderr, "ASYNCHRONOUS %s", buffer);
-    riak_serverinfo_response_free(cfg, &response);
+    riak_serverinfo_response_free(conn->cfg, &response);
 }
 
 /**

--- a/test/cunit/test_serverinfo.c
+++ b/test/cunit/test_serverinfo.c
@@ -168,10 +168,8 @@ test_serverinfo_async_cb(riak_serverinfo_response *response,
  */
 void*
 test_serverinfo_async_thread(void *ptr) {
-    // Make thread-local copy
-    test_async_pthread_args args;
-    memcpy(&args, ptr, sizeof(test_async_pthread_args));
-    test_async_connection *conn = args.conn;
+    test_async_pthread *state = (test_async_pthread*)ptr;
+    test_async_connection *conn = state->conn;
     riak_error err = riak_async_register_serverinfo(conn->rop, (riak_response_callback)test_serverinfo_async_cb);
     if (err) {
         return (void*)riak_strerror(err);
@@ -188,8 +186,7 @@ test_integration_async_server_info() {
     riak_error err = test_setup(&cfg);
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
-    test_async_pthread_args args;
-    err = test_async_thread_runner(cfg, test_serverinfo_async_thread, &args);
+    err = test_async_thread_runner(cfg, test_serverinfo_async_thread, NULL);
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
     test_cleanup(&cfg);

--- a/test/cunit/test_serverinfo.c
+++ b/test/cunit/test_serverinfo.c
@@ -30,6 +30,7 @@
 #include "riak.h"
 #include "riak_messages-internal.h"
 #include "riak_operation-internal.h"
+#include "test.h"
 
 void
 test_server_info_encode_request() {
@@ -119,3 +120,79 @@ test_server_info_decode_bad_response() {
     CU_ASSERT_FATAL(err != ERIAK_OK)
     CU_PASS("test_server_info_decode_bad_response passed")
 }
+
+void
+test_integration_server_info() {
+    riak_config     *cfg;
+    riak_connection *cxn = NULL;
+
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    err = test_connect(cfg, &cxn);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    riak_serverinfo_response *response = NULL;
+    err = riak_serverinfo(cxn, &response);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    char buffer[1024];
+    riak_serverinfo_response_print(response, buffer, sizeof(buffer));
+    fprintf(stderr, "%s", buffer);
+    riak_serverinfo_response_free(cfg, &response);
+    test_disconnect(cfg, &cxn);
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_server_info passed")
+}
+
+/**
+ * @brief Callback for Server Info message
+ * @param response Server Info response
+ * @parm ptr Riak Operation
+ */
+void
+test_serverinfo_async_cb(riak_serverinfo_response *response,
+                         void                     *ptr) {
+    riak_operation   *rop = (riak_operation*)ptr;
+    riak_connection  *cxn = riak_operation_get_connection(rop);
+    riak_config      *cfg = riak_connection_get_config(cxn);
+    char buffer[1024];
+    riak_serverinfo_response_print(response, buffer, sizeof(buffer));
+    fprintf(stderr, "ASYNCHRONOUS %s", buffer);
+    riak_serverinfo_response_free(cfg, &response);
+}
+
+/**
+ * @brief Encode and Send a Server Info request
+ * @param args Parameters required to create Server Info request
+ */
+void*
+test_serverinfo_async_thread(void *ptr) {
+    // Make thread-local copy
+    test_async_pthread_args args;
+    memcpy(&args, ptr, sizeof(test_async_pthread_args));
+    test_async_connection *conn = args.conn;
+    riak_error err = riak_async_register_serverinfo(conn->rop, (riak_response_callback)test_serverinfo_async_cb);
+    if (err) {
+        return (void*)riak_strerror(err);
+    }
+    err = test_async_send_message(conn);
+    if (err) {
+        return (void*)"Could not send request";
+    }
+    return NULL;
+}
+void
+test_integration_async_server_info() {
+    riak_config           *cfg;
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    test_async_pthread_args args;
+    err = test_async_thread_runner(cfg, test_serverinfo_async_thread, &args);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_async_server_info passed")
+}
+


### PR DESCRIPTION
- Ported all tests from CppUTest back to CUnit to keep things 99.44% pure
- Tested build on OSX 10.9.2 and Ubuntu 13.10
- Fixed how CUnit was reporting its errors back to `make`
- Fixed a `riak_binary` test
- Added integration tests for ping, server info, list keys and list buckets
- Other messages to follow in subsequent PRs
