### PR TITLE
riak_free -> riak_binary_free

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -526,11 +526,11 @@ main(int   argc,
 
     // cleanup
     event_base_free(base);
-    riak_free(cfg, &bucket_bin);
-    riak_free(cfg, &key_bin);
-    riak_free(cfg, &value_bin);
-    riak_free(cfg, &index_bin);
-    riak_free(cfg, &content_type);
+    riak_binary_free(cfg, &bucket_bin);
+    riak_binary_free(cfg, &key_bin);
+    riak_binary_free(cfg, &value_bin);
+    riak_binary_free(cfg, &index_bin);
+    riak_binary_free(cfg, &content_type);
     riak_config_free(&cfg);
 
     return 0;

--- a/src/messages/riak_2index.c
+++ b/src/messages/riak_2index.c
@@ -306,12 +306,12 @@ riak_2index_options_free(riak_config          *cfg,
 
     riak_2index_options *opt = *options;
 
-    riak_free(cfg, &(opt->key));
-    riak_free(cfg, &(opt->range_min));
-    riak_free(cfg, &(opt->range_max));
-    riak_free(cfg, &(opt->type));
-    riak_free(cfg, &(opt->continuation));
-    riak_free(cfg, &(opt->term_regex));
+    riak_binary_free(cfg, &(opt->key));
+    riak_binary_free(cfg, &(opt->range_min));
+    riak_binary_free(cfg, &(opt->range_max));
+    riak_binary_free(cfg, &(opt->type));
+    riak_binary_free(cfg, &(opt->continuation));
+    riak_binary_free(cfg, &(opt->term_regex));
     riak_free(cfg, options);
 }
 

--- a/src/messages/riak_delete.c
+++ b/src/messages/riak_delete.c
@@ -159,8 +159,10 @@ riak_delete_options_print(riak_delete_options  *opt,
 
 void
 riak_delete_options_free(riak_config  *cfg,
-                 riak_delete_options **opt) {
-    riak_free(cfg, opt);
+                 riak_delete_options **options) {
+    riak_delete_options *opt = *options;
+    riak_binary_free(cfg, &(opt->vclock));
+    riak_free(cfg, options);
 }
 
 //
@@ -228,7 +230,7 @@ riak_delete_options_set_vclock(riak_config      *cfg,
                             riak_binary      *value) {
     opt->has_vclock = RIAK_TRUE;
     if (opt->vclock) {
-        riak_free(cfg, &opt->vclock);
+        riak_binary_free(cfg, &opt->vclock);
     }
     opt->vclock = riak_binary_copy(cfg, value);
 }

--- a/src/messages/riak_get_clientid.c
+++ b/src/messages/riak_get_clientid.c
@@ -94,7 +94,7 @@ riak_get_clientid_response_free(riak_config                 *cfg,
                                 riak_get_clientid_response **resp) {
     riak_get_clientid_response *response = *resp;
     if (response == NULL) return;
-    riak_free(cfg, &(response->client_id));
+    riak_binary_free(cfg, &(response->client_id));
     rpb_get_client_id_resp__free_unpacked(response->_internal, cfg->pb_allocator);
     riak_free(cfg, resp);
 }

--- a/src/messages/riak_listbuckets.c
+++ b/src/messages/riak_listbuckets.c
@@ -177,7 +177,7 @@ riak_listbuckets_response_free(riak_config                *cfg,
     if (response == NULL) return;
     int i;
     for(i = 0; i < response->n_buckets; i++) {
-        riak_free(cfg, &(response->buckets[i]));
+        riak_binary_free(cfg, &(response->buckets[i]));
     }
     riak_free(cfg, &(response->buckets));
     if (response->n_responses > 0) {

--- a/src/messages/riak_listkeys.c
+++ b/src/messages/riak_listkeys.c
@@ -180,7 +180,7 @@ riak_listkeys_response_free(riak_config             *cfg,
     if (response == NULL) return;
     int i;
     for(i = 0; i < response->n_keys; i++) {
-        riak_response_free(cfg, &(response->keys[i]));
+        riak_binary_free(cfg, &(response->keys[i]));
     }
     riak_free(cfg, &(response->keys));
     if (response->n_responses > 0) {

--- a/src/messages/riak_listkeys.c
+++ b/src/messages/riak_listkeys.c
@@ -180,7 +180,7 @@ riak_listkeys_response_free(riak_config             *cfg,
     if (response == NULL) return;
     int i;
     for(i = 0; i < response->n_keys; i++) {
-        riak_free(cfg, &(response->keys[i]));
+        riak_response_free(cfg, &(response->keys[i]));
     }
     riak_free(cfg, &(response->keys));
     if (response->n_responses > 0) {

--- a/src/messages/riak_put.c
+++ b/src/messages/riak_put.c
@@ -127,6 +127,8 @@ riak_free_put_request(riak_config        *cfg,
                       riak_put_response **resp) {
     riak_put_response *response = *resp;
     if (response == NULL) return;
+    riak_binary_free(cfg, &(response->key));
+    riak_binary_free(cfg, &(response->vclock));
     rpb_put_resp__free_unpacked(response->_internal, cfg->pb_allocator);
     riak_free(cfg, resp);
 }

--- a/src/messages/riak_serverinfo.c
+++ b/src/messages/riak_serverinfo.c
@@ -114,8 +114,8 @@ riak_serverinfo_response_free(riak_config               *cfg,
     riak_serverinfo_response *response = *resp;
     if (response == NULL) return;
     rpb_get_server_info_resp__free_unpacked(response->_internal, cfg->pb_allocator);
-    riak_free(cfg, &(response->node));
-    riak_free(cfg, &(response->server_version));
+    riak_binary_free(cfg, &(response->node));
+    riak_binary_free(cfg, &(response->server_version));
     riak_free(cfg, resp);
 }
 

--- a/src/riak_bucketprops.c
+++ b/src/riak_bucketprops.c
@@ -120,8 +120,8 @@ void
 riak_modfun_free(riak_config   *cfg,
                   riak_modfun **mod_fun_target) {
     riak_modfun *mod_fun = *mod_fun_target;
-    riak_free(cfg, &(mod_fun->module));
-    riak_free(cfg, &(mod_fun->function));
+    riak_binary_free(cfg, &(mod_fun->module));
+    riak_binary_free(cfg, &(mod_fun->function));
     riak_free(cfg, mod_fun_target);
 }
 
@@ -319,7 +319,7 @@ riak_commit_hooks_free(riak_config        *cfg,
     riak_commit_hook **hook = *hook_target;
     int i;
     for(i = 0; i < num_hooks; i++) {
-        riak_free(cfg, &(hook[i]->name));
+        riak_binary_free(cfg, &(hook[i]->name));
         riak_modfun_free(cfg, &(hook[i]->modfun));
         riak_free(cfg, &(hook[i]));
     }
@@ -761,12 +761,12 @@ void
 riak_bucketprops_free(riak_config       *cfg,
                       riak_bucketprops **props) {
     riak_bucketprops* prop = *props;
-    riak_free(cfg, &(prop->backend));
+    riak_binary_free(cfg, &(prop->backend));
     riak_modfun_free(cfg, &(prop->chash_keyfun));
     riak_modfun_free(cfg, &(prop->linkfun));
     riak_commit_hooks_free(cfg, &(prop->precommit), prop->n_precommit);
     riak_commit_hooks_free(cfg, &(prop->postcommit), prop->n_postcommit);
-    riak_free(cfg, &(prop->search_index));
+    riak_binary_free(cfg, &(prop->search_index));
     riak_free(cfg, props);
 }
 


### PR DESCRIPTION
using `riak_free()` on a `riak_binary` (aka `struct _riak_binary`) results in a memory leak
