### PR TITLE
Add GET message integration test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -154,7 +154,8 @@ riak_c_cunit_SOURCES = test/cunit/test.c \
 			test/cunit/test_connection.c \
 			test/cunit/test_delete.c \
 			test/cunit/test_get.c \
-			test/cunit/test_mapreduce.c \
+			test/cunit/test_log.c \
+  			test/cunit/test_mapreduce.c \
 			test/cunit/test_operation.c \
 			test/cunit/test_listbuckets.c \
 			test/cunit/test_listkeys.c \

--- a/src/include/riak_binary.h
+++ b/src/include/riak_binary.h
@@ -54,7 +54,7 @@ riak_binary_new_shallow(riak_config  *cfg,
                         riak_uint8_t *data);
 
 /**
- * @brief Determine if two binaries have the same value
+ * @brief Determine if two non-NULL binaries have the same value
  * @param bin1 First Riak Binary
  * @param bin2 Second Riak Binary
  * @returns 0 if equal, -1 if bin1<bin2, 1 if bin1>bin2

--- a/src/include/riak_binary.h
+++ b/src/include/riak_binary.h
@@ -54,6 +54,26 @@ riak_binary_new_shallow(riak_config  *cfg,
                         riak_uint8_t *data);
 
 /**
+ * @brief Determine if two binaries have the same value
+ * @param bin1 First Riak Binary
+ * @param bin2 Second Riak Binary
+ * @returns 0 if equal, -1 if bin1<bin2, 1 if bin1>bin2
+ */
+int
+riak_binary_compare(riak_binary *bin1,
+                    riak_binary *bin2);
+
+/**
+ * @brief Determine if a binary and a string have the same value
+ * @param bin Riak Binary
+ * @param str NULL-terminated ASCII string
+ * @returns 0 if equal, -1 if bin<str, 1 if bin>str
+ */
+int
+riak_binary_compare_string(riak_binary *bin,
+                           const char  *str);
+
+/**
  * @brief Allocate a new `riak_binary` struct
  * @param cfg Riak Configuration
  * @param bin Original Riak Binary

--- a/src/include/riak_error.h
+++ b/src/include/riak_error.h
@@ -29,6 +29,7 @@ extern "C" {
 
 typedef enum riak_error_enum {
     ERIAK_OK = 0,
+    ERIAK_TEST_FAILURE,
     ERIAK_OUT_OF_RANGE,
     ERIAK_DNS_RESOLUTION,
     ERIAK_CONNECT,
@@ -50,6 +51,7 @@ typedef enum riak_error_enum {
 #ifdef _RIAK_ERROR_DEFINE_MSGS
 static const char* errmsgs[] = {
     "No Error",
+    "Test Failure",
     "Value out of Range",
     "Problems resolving host name/port number",
     "Connection Error",

--- a/src/include/riak_error.h
+++ b/src/include/riak_error.h
@@ -43,6 +43,7 @@ typedef enum riak_error_enum {
     ERIAK_SERVER_ERROR,
     ERIAK_MESSAGE_FORMAT,
     ERIAK_THREAD,
+    ERIAK_INVALID,
     ERIAK_LAST_ERRORNUM
 } riak_error;
 
@@ -63,6 +64,7 @@ static const char* errmsgs[] = {
     "An error was returned from the server",
     "Message Format Error",
     "Threading Error",
+    "Invalid Value",
     "SENTINEL FOR LAST ERROR MESSAGE"
 };
 #endif

--- a/src/include/riak_object.h
+++ b/src/include/riak_object.h
@@ -45,7 +45,7 @@ riak_object_new(riak_config *cfg);
  * @param obj Riak Object to be freed
  */
 void
-riak_object_free(riak_config *cfg,
+riak_object_free(riak_config  *cfg,
                  riak_object **obj);
 
 /**
@@ -62,26 +62,22 @@ riak_object_print(riak_print_state *state,
  * @brief Compare two Riak Objects
  * @param obj1 First Riak Object
  * @param obj2 Second RiaK Object
- * @param exact_match Set to RIAK_TRUE to compare vtag and modified timestamps
  * @returns 0 if they are equal in value, 1 otherwise
  */
 int
 riak_object_compare(riak_object   *obj1,
-                    riak_object   *obj2,
-                    riak_boolean_t exact_match);
+                    riak_object   *obj2);
 
 /**
  * @brief Compare two Riak Objects and print differences to stderr
  * @param obj1 First Riak Object
  * @param obj2 Second RiaK Object
- * @param exact_match Set to RIAK_TRUE to compare vtag and modified timestamps
  * @param debug Riak Print State where to write the differences
  * @returns 0 if they are equal in value, 1 otherwise
  */
 int
 riak_object_compare_debug(riak_object      *obj1,
                           riak_object      *obj2,
-                          riak_boolean_t    exact_match,
                           riak_print_state *debug);
 
 /**

--- a/src/include/riak_object.h
+++ b/src/include/riak_object.h
@@ -59,6 +59,32 @@ riak_object_print(riak_print_state *state,
                   riak_object      *obj);
 
 /**
+ * @brief Compare two Riak Objects
+ * @param obj1 First Riak Object
+ * @param obj2 Second RiaK Object
+ * @param exact_match Set to RIAK_TRUE to compare vtag and modified timestamps
+ * @returns 0 if they are equal in value, 1 otherwise
+ */
+int
+riak_object_compare(riak_object   *obj1,
+                    riak_object   *obj2,
+                    riak_boolean_t exact_match);
+
+/**
+ * @brief Compare two Riak Objects and print differences to stderr
+ * @param obj1 First Riak Object
+ * @param obj2 Second RiaK Object
+ * @param exact_match Set to RIAK_TRUE to compare vtag and modified timestamps
+ * @param debug Riak Print State where to write the differences
+ * @returns 0 if they are equal in value, 1 otherwise
+ */
+int
+riak_object_compare_debug(riak_object      *obj1,
+                          riak_object      *obj2,
+                          riak_boolean_t    exact_match,
+                          riak_print_state *debug);
+
+/**
  * @brief Allocate an array of `riak_object` pointers
  * @param cfg Riak Configuration
  * @param array Returned array of pointers to `riak_object`s
@@ -67,7 +93,7 @@ riak_object_print(riak_print_state *state,
  * @returns Error Code
  */
 riak_error
-riak_object_new_array(riak_config  *cfg,
+riak_object_new_array(riak_config   *cfg,
                       riak_object ***array,
                       riak_size_t    len);
 

--- a/src/messages/riak_put.c
+++ b/src/messages/riak_put.c
@@ -110,6 +110,7 @@ riak_put_request_encode(riak_operation   *rop,
         return ERIAK_OUT_OF_MEMORY;
     }
     rpb_put_req__pack (&putmsg, msgbuf);
+    riak_object_free_pb(cfg, &content);
 
     riak_pb_message* request = riak_pb_message_new(cfg, MSG_RPBPUTREQ, msglen, msgbuf);
     if (request == NULL) {

--- a/src/riak.c
+++ b/src/riak.c
@@ -42,8 +42,7 @@ riak_sync_read_cb(void       *ptr,
     if (result < 0) {
         char message[256];
         strerror_r(errno, message, sizeof(message));
-        printf("%s\n", message);
-        abort();
+        fprintf(stderr, "%s\n", message);
     }
     return result;
 }

--- a/src/riak.c
+++ b/src/riak.c
@@ -82,7 +82,8 @@ riak_sync_request(riak_operation **rop_target,
 riak_error
 riak_ping(riak_connection *cxn) {
     riak_operation *rop = NULL;
-    riak_error err = riak_operation_new(cxn, &rop, NULL, NULL, NULL);
+    riak_error err   = riak_operation_new(cxn, &rop, NULL, NULL, NULL);
+    riak_config *cfg = riak_connection_get_config(cxn);
     if (err) {
         return err;
     }
@@ -95,10 +96,10 @@ riak_ping(riak_connection *cxn) {
     if (err) {
         return err;
     }
-    if (response->success != RIAK_TRUE) {
-        return ERIAK_NO_PING;
-    }
-    return ERIAK_OK;
+    err = (response->success) ? ERIAK_OK : ERIAK_NO_PING;
+    riak_free(cfg, &response);
+
+    return err;
 }
 
 riak_error
@@ -173,6 +174,7 @@ riak_delete(riak_connection    *cxn,
            riak_binary         *key,
            riak_delete_options *opts) {
     riak_operation *rop = NULL;
+    riak_config    *cfg = riak_connection_get_config(cxn);
     riak_error err = riak_operation_new(cxn, &rop, NULL, NULL, NULL);
     if (err) {
         return err;
@@ -181,11 +183,12 @@ riak_delete(riak_connection    *cxn,
     if (err) {
         return err;
     }
-    riak_get_response *response = NULL;
+    riak_delete_response *response = NULL;
     err = riak_sync_request(&rop, (void**)&response);
     if (err) {
         return err;
     }
+    riak_delete_response_free(cfg, &response);
 
     return ERIAK_OK;
 }

--- a/src/riak_binary.c
+++ b/src/riak_binary.c
@@ -65,6 +65,31 @@ riak_binary_new_shallow(riak_config  *cfg,
     return b;
 }
 
+int
+riak_binary_compare(riak_binary *bin1,
+                    riak_binary *bin2) {
+    if (bin1->len > bin2->len) {
+        return 1;
+    }
+    if (bin1->len < bin2->len) {
+        return -1;
+    }
+    return memcmp(bin1->data, bin2->data, bin1->len);
+}
+
+int
+riak_binary_compare_string(riak_binary *bin,
+                           const char  *str) {
+    int len = strlen(str);
+    if (bin->len > len) {
+        return 1;
+    }
+    if (bin->len < len) {
+        return -1;
+    }
+    return memcmp(bin->data, str, bin->len);
+}
+
 riak_binary*
 riak_binary_copy(riak_config *cfg,
                  riak_binary *bin) {

--- a/src/riak_object.c
+++ b/src/riak_object.c
@@ -308,7 +308,7 @@ riak_links_free(riak_config  *cfg,
         riak_binary_free(cfg, &(link[i]->tag));
         riak_free(cfg, &(link[i]));
     }
-    riak_free(cfg, *link_target);
+    riak_free(cfg, link_target);
 }
 
 riak_int32_t
@@ -754,7 +754,7 @@ riak_object_free(riak_config *cfg,
 
 void
 riak_object_free_pb(riak_config *cfg,
-                    RpbContent   *obj) {
+                    RpbContent  *obj) {
     riak_pairs_free_pb(cfg, &(obj->indexes), obj->n_indexes);
     riak_pairs_free_pb(cfg, &(obj->usermeta), obj->n_usermeta);
     riak_links_free_pb(cfg, &(obj->links), obj->n_links);

--- a/src/riak_object.c
+++ b/src/riak_object.c
@@ -193,6 +193,7 @@ riak_pair_set_value(riak_config *cfg,
     if (pair->value == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
+    pair->has_value = RIAK_TRUE;
     return ERIAK_OK;
 }
 
@@ -275,14 +276,14 @@ riak_links_copy_from_pb(riak_config  *cfg,
             }
         }
         if (pblink[i]->has_key) {
-            pblink[i]->has_key = RIAK_TRUE;
+            link[i]->has_key = RIAK_TRUE;
             link[i]->key = riak_binary_copy_from_pb(cfg, &(pblink[i]->key));
             if (link[i]->key == NULL) {
                 return ERIAK_OUT_OF_MEMORY;
             }
         }
         if (pblink[i]->has_tag) {
-            pblink[i]->has_tag = RIAK_TRUE;
+            link[i]->has_tag = RIAK_TRUE;
             link[i]->tag = riak_binary_copy_from_pb(cfg, &(pblink[i]->tag));
             if (link[i]->tag == NULL) {
                 return ERIAK_OUT_OF_MEMORY;
@@ -568,6 +569,126 @@ riak_object_new_from_pb(riak_config  *cfg,
     return err;
 }
 
+static int
+riak_object_compare_binary(const char             *message,
+                                 riak_print_state *state,
+                                 riak_binary      *bin1,
+                                 riak_binary      *bin2) {
+    int result = riak_binary_compare(bin1, bin2);
+    if (state && result) {
+        riak_print(state, "Object %s differ: ", message);
+        riak_print_binary(state, bin1);
+        riak_print(state, " vs ");
+        riak_print_binary(state, bin2);
+        riak_print(state, "\n");
+    }
+    return result;
+}
+
+static int
+riak_object_compare_int(const char       *message,
+                        riak_print_state *state,
+                        riak_uint32_t     int1,
+                        riak_uint32_t     int2) {
+    int result = (int1 != int2);
+    if (state && result) {
+        riak_print(state, "Object %s differ: %d vs %d\n", message, int1, int2);
+    }
+    return result;
+}
+
+static int
+riak_object_compare_internal(riak_object      *obj1,
+                             riak_object      *obj2,
+                             riak_boolean_t    exact_match,
+                             riak_print_state *debug) {
+    int result = riak_object_compare_binary("Buckets", debug, obj1->bucket, obj2->bucket);
+    if (result) return result;
+    result = riak_object_compare_binary("Keys", debug, obj1->key, obj2->key);
+    if (result) return result;
+    result = riak_object_compare_binary("Values", debug, obj1->value, obj2->value);
+    if (result) return result;
+    result = riak_object_compare_binary("Charset", debug, obj1->charset, obj2->charset);
+    if (result) return result;
+    result = riak_object_compare_binary("Content Types", debug, obj1->content_type, obj2->content_type);
+    if (result) return result;
+    result = riak_object_compare_binary("Encodings", debug, obj1->encoding, obj2->encoding);
+    if (result) return result;
+    if (exact_match) {
+        result = riak_object_compare_binary("VTags", debug, obj1->vtag, obj2->vtag);
+        if (result) return result;
+        result = riak_object_compare_int("Last Modified Dates", debug, obj1->last_mod, obj2->last_mod);
+        if (result) return result;
+        result = riak_object_compare_int("Last Modified uSecs", debug, obj1->last_mod_usecs, obj2->last_mod_usecs);
+        if (result) return result;
+    }
+    result = riak_object_compare_int("Delete Flags", debug, obj1->deleted, obj2->deleted);
+    if (result) return result;
+    result = riak_object_compare_int("Number of Indexes", debug, obj1->n_indexes, obj2->n_indexes);
+    if (result) return result;
+    result = riak_object_compare_int("Number of Links", debug, obj1->n_links, obj2->n_links);
+    if (result) return result;
+    result = riak_object_compare_int("Number of User Metadata", debug, obj1->n_usermeta, obj2->n_usermeta);
+    if (result) return result;
+
+    for(int i = 0; i < obj1->n_indexes; i++) {
+        result = riak_object_compare_int("Index Value Flags", debug, obj1->indexes[i]->has_value, obj2->indexes[i]->has_value);
+        if (result) return result;
+        result = riak_object_compare_binary("Index Keys", debug, obj1->indexes[i]->key, obj2->indexes[i]->key);
+        if (result) return result;
+        if (obj1->indexes[i]->has_value) {
+            result = riak_object_compare_binary("Index Values", debug, obj1->indexes[i]->value, obj2->indexes[i]->value);
+            if (result) return result;
+        }
+    }
+    for(int i = 0; i < obj1->n_links; i++) {
+        result = riak_object_compare_int("Link Bucket Flags", debug, obj1->links[i]->has_bucket, obj2->links[i]->has_bucket);
+        if (result) return result;
+        result = riak_object_compare_int("Link Key Flags", debug, obj1->links[i]->has_key, obj2->links[i]->has_key);
+        if (result) return result;
+        result = riak_object_compare_int("Link Tag Flags", debug, obj1->links[i]->has_tag, obj2->links[i]->has_tag);
+        if (result) return result;
+        if (obj1->links[i]->has_bucket) {
+            result = riak_object_compare_binary("Link Buckets", debug, obj1->links[i]->bucket, obj2->links[i]->bucket);
+            if (result) return result;
+        }
+        if (obj1->links[i]->has_key) {
+            result = riak_object_compare_binary("Link Keys", debug, obj1->links[i]->key, obj2->links[i]->key);
+            if (result) return result;
+        }
+        if (obj1->links[i]->has_tag) {
+            result = riak_object_compare_binary("Link Tags", debug, obj1->links[i]->tag, obj2->links[i]->tag);
+            if (result) return result;
+        }
+    }
+    for(int i = 0; i < obj1->n_usermeta; i++) {
+        result = riak_object_compare_int("User Meta-data Value Flags", debug, obj1->usermeta[i]->has_value, obj2->usermeta[i]->has_value);
+        if (result) return result;
+        result = riak_object_compare_binary("User Meta-data Keys", debug, obj1->usermeta[i]->key, obj2->usermeta[i]->key);
+        if (result) return result;
+        if (obj1->usermeta[i]->has_value) {
+            result = riak_object_compare_binary("User Meta-data Values", debug, obj1->usermeta[i]->value, obj2->usermeta[i]->value);
+            if (result) return result;
+        }
+    }
+    return 0;
+}
+
+int
+riak_object_compare(riak_object   *obj1,
+                    riak_object   *obj2,
+                    riak_boolean_t exact_match) {
+    return riak_object_compare_internal(obj1, obj2, exact_match, NULL);
+}
+
+int
+riak_object_compare_debug(riak_object      *obj1,
+                          riak_object      *obj2,
+                          riak_boolean_t    exact_match,
+                          riak_print_state *state) {
+    return riak_object_compare_internal(obj1, obj2, exact_match, state);
+}
+
 riak_int32_t
 riak_object_print(riak_print_state *state,
                   riak_object      *obj) {
@@ -601,10 +722,13 @@ riak_object_print(riak_print_state *state,
         wrote += riak_print_label_binary(state, "VTag", obj->vtag);
     }
 
-    int i;
-    for(i = 0; i < obj->n_links; i++) {
+    for(int i = 0; i < obj->n_links; i++) {
         wrote += riak_links_print(state, obj->links[i]);
     }
+    wrote += riak_print(state, "%s\n", "User Meta-data");
+    wrote += riak_pairs_print(state, obj->usermeta, obj->n_usermeta);
+    wrote += riak_print(state, "%s\n", "Indexes");
+    wrote += riak_pairs_print(state, obj->indexes, obj->n_indexes);
     return wrote;
 }
 

--- a/src/riak_operation.c
+++ b/src/riak_operation.c
@@ -134,3 +134,4 @@ riak_binary*
 riak_operation_get_index(riak_operation *rop) {
     return rop->request.index;
 }
+

--- a/src/riak_utils.c
+++ b/src/riak_utils.c
@@ -60,7 +60,7 @@ riak_strlcat(char       *dst,
 }
 
 void**
-riak_array_realloc(riak_config *cfg,
+riak_array_realloc(riak_config  *cfg,
                    void       ***from,
                    riak_size_t   size,
                    riak_uint32_t oldnum,

--- a/test/cunit/include/test.h
+++ b/test/cunit/include/test.h
@@ -38,6 +38,7 @@
 #define RIAK_TEST_MAX_KEYS          50
 #define RIAK_TEST_BUCKET_KEY_LEN    20
 #define RIAK_TEST_VALUE_LEN         200
+#define RIAK_TEST_NUM_OBJ_EXTRAS    3 // Number of test object indexes, meta-data and links
 
 #define RIAK_TEST_HOST          "RIAK_TEST_HOST"
 #define RIAK_TEST_PB_PORT       "RIAK_TEST_PB_PORT"

--- a/test/cunit/include/test_bucket_key_value.h
+++ b/test/cunit/include/test_bucket_key_value.h
@@ -24,9 +24,10 @@
 #define _TEST_BUCKET_KEY_VALUE_
 
 typedef struct _test_bucket_key_value {
-    riak_binary *bucket;
-    riak_binary *key;
-    riak_binary *value;
+    riak_binary  *bucket;
+    riak_binary  *key;
+    riak_uint32_t n_objs;
+    riak_object **objs;
     struct _test_bucket_key_value *next;
 } test_bucket_key_value;
 
@@ -36,7 +37,7 @@ typedef struct _test_bucket_key_value {
  * @param root Updated first link in linked list of BKVs
  * @param bucket Name of bucket
  * @param key Name of key
- * @param value Value
+ * @param obj Riak Object (optional)
  * @returns Error Code
  */
 riak_error
@@ -44,7 +45,7 @@ test_bkv_add(riak_config            *cfg,
              test_bucket_key_value **root,
              riak_binary            *bucket,
              riak_binary            *key,
-             riak_binary            *value);
+             riak_object            *obj);
 
 /**
  * @brief Frees the entire linked list of Bucket/Key/Values

--- a/test/cunit/include/test_bucket_key_value.h
+++ b/test/cunit/include/test_bucket_key_value.h
@@ -53,6 +53,6 @@ test_bkv_add(riak_config            *cfg,
  * @param root First link in linked list of BKVs
  */
 void
-test_bkv_free(riak_config *cfg,
+test_bkv_free(riak_config            *cfg,
               test_bucket_key_value **root);
 #endif //_TEST_BUCKET_KEY_VALUE_

--- a/test/cunit/include/test_get.h
+++ b/test/cunit/include/test_get.h
@@ -42,3 +42,9 @@ void
 test_get_options_n_val();
 void
 test_get_decode_response();
+void
+test_integration_get_value();
+void
+test_integration_async_get_value();
+void
+test_integration_async_get_bad_value();

--- a/test/cunit/registry.c
+++ b/test/cunit/registry.c
@@ -165,6 +165,9 @@ main(int   argc,
     CU_ADD_TEST(integration_suite, test_integration_async_listbuckets);
     CU_ADD_TEST(integration_suite, test_integration_listkeys);
     CU_ADD_TEST(integration_suite, test_integration_async_listkeys);
+    CU_ADD_TEST(integration_suite, test_integration_get_value);
+    CU_ADD_TEST(integration_suite, test_integration_async_get_value);
+    CU_ADD_TEST(integration_suite, test_integration_async_get_bad_value);
 
     // Run all tests using the CUnit Basic interface
     CU_basic_set_mode(CU_BRM_VERBOSE);

--- a/test/cunit/test.c
+++ b/test/cunit/test.c
@@ -33,7 +33,11 @@
 
 riak_error
 test_setup(riak_config **cfg) {
-    return riak_config_new_default(cfg);
+    riak_error err = riak_config_new_default(cfg);
+    if (err == ERIAK_OK) {
+        err = riak_config_set_logging(*cfg, NULL, test_log, NULL, NULL);
+    }
+    return err;
 }
 
 riak_error
@@ -69,14 +73,15 @@ test_cleanup(riak_config **cfg) {
 void
 riak_test_error_cb(void *resp,
                    void *ptr) {
-    test_async_connection *conn = (test_async_connection*)ptr;
+    test_async_pthread    *state = (test_async_pthread*)ptr;
+    test_async_connection *conn  = state->conn;
     char message[1024];
     riak_server_error *error = riak_operation_get_server_error(conn->rop);
     if (error) {
         riak_binary_print(riak_server_error_get_errmsg(error), message, sizeof(message));
         fprintf(stderr, "SERVER ERROR: %s\n", message);
-        conn->err      = ERIAK_SERVER_ERROR;
-        strncpy(conn->err_msg, message, sizeof(conn->err_msg));
+        state->err      = ERIAK_SERVER_ERROR;
+        strncpy(state->err_msg, message, sizeof(state->err_msg));
     }
 }
 
@@ -89,8 +94,6 @@ test_async_connect(riak_config            *cfg,
     }
     test_async_connection *conn = *conn_out;
     conn->cfg        = cfg;
-    conn->err        = ERIAK_OK; // Returned error state
-    conn->err_msg[0] = '\0';
     riak_error err = test_connect(cfg, &(conn->cxn));
     if (err) {
         fprintf(stderr, "Could not connect to Riak\n");
@@ -119,7 +122,6 @@ test_async_connect(riak_config            *cfg,
         return err;
     }
     riak_operation_set_error_cb(conn->rop, riak_test_error_cb);
-    riak_operation_set_cb_data(conn->rop, conn);
 
     return err;
 }
@@ -139,7 +141,8 @@ test_async_disconnect(test_async_connection **conn_out) {
 riak_error
 test_async_thread_runner(riak_config             *cfg,
                          test_async_pthread_fun   f,
-                         void                    *args) {
+                         void                    *args,
+                         void                    *expected) {
     test_async_pthread state[RIAK_TEST_NUM_THREADS];
     riak_error err = ERIAK_OK;
     for(int i = 0; i < RIAK_TEST_NUM_THREADS; i++) {
@@ -147,7 +150,13 @@ test_async_thread_runner(riak_config             *cfg,
         if (err) {
             return err;
         }
-        state[i].args = args;
+        state[i].args       = args;
+        state[i].expected   = expected;
+        state[i].err        = ERIAK_OK; // Returned error flag
+        state[i].err_msg[0] = '\0';
+
+        // Pass the whole state to the callback
+        riak_operation_set_cb_data(state[i].conn->rop, &(state[i]));
 
         int status = pthread_create(&(state[i].tid), NULL, f, &(state[i]));
         if (status != 0) {
@@ -159,17 +168,17 @@ test_async_thread_runner(riak_config             *cfg,
     }
 
     for(int i = 0; i < RIAK_TEST_NUM_THREADS; i++) {
-        int status = pthread_join(state[i].tid, &(state[i].result));
+        int status = pthread_join(state[i].tid, &(state[i].pthread_result));
         if (status != 0) {
             err = ERIAK_THREAD;
         }
-        if (state[i].result != NULL) {
-            fprintf(stderr, "THREAD ERROR: %s\n", (char*)(state[i].result));
+        if (state[i].pthread_result != NULL) {
+            fprintf(stderr, "THREAD ERROR: %s\n", (char*)(state[i].pthread_result));
             err = ERIAK_THREAD;
         }
-        if (state[i].conn->err) {
-            fprintf(stderr, "CALLBACK ERROR: %s\n", state[i].conn->err_msg);
-            err = state[i].conn->err;
+        if (state[i].err) {
+            fprintf(stderr, "CALLBACK ERROR: %s\n", state[i].err_msg);
+            err = state[i].err;
         }
     }
     for(int i = 0; i < RIAK_TEST_NUM_THREADS; i++) {
@@ -192,58 +201,194 @@ test_random_string(riak_config  *cfg,
     return result;
 }
 
+riak_binary*
+test_random_binary(riak_config  *cfg,
+                   riak_uint32_t len) {
+    char *result = test_random_string(cfg, len);
+    if (result == NULL) {
+        return NULL;
+    }
+    return riak_binary_new_shallow(cfg, len, (riak_uint8_t*)result);
+}
+
+int
+test_random_int() {
+    return rand();
+}
+
+riak_boolean_t
+test_random_bool() {
+    return (rand() % 2) ? RIAK_TRUE : RIAK_FALSE;
+}
+
+typedef riak_error (*test_object_field)(riak_config*,riak_object*,riak_binary*);
+
+riak_error
+test_load_dummy_object_field(riak_config      *cfg,
+                             riak_object      *obj,
+                             riak_uint32_t     len,
+                             test_object_field fn) {
+    if (len == 0) len = RIAK_TEST_BUCKET_KEY_LEN;
+    riak_binary *value = test_random_binary(cfg, len);
+    if (value == NULL) {
+        return ERIAK_OUT_OF_MEMORY;
+    }
+    riak_error err = fn(cfg, obj, value);
+    riak_binary_free(cfg, &value);
+    return err;
+}
+
+riak_error
+test_load_dummy_object(riak_config            *cfg,
+                       riak_binary            *bucket,
+                       riak_binary            *key,
+                       riak_object           **obj_out,
+                       test_bucket_key_value **root) {
+    riak_object *obj = riak_object_new(cfg);
+    if (obj == NULL) {
+        return ERIAK_OUT_OF_MEMORY;
+    }
+    riak_error err = riak_object_set_bucket(cfg, obj, bucket);
+    if (err) {
+        fprintf(stderr, "Could not add bucket to dummy object\n");
+        return err;
+    }
+    err = riak_object_set_key(cfg, obj, key);
+    if (err) {
+        fprintf(stderr, "Could not add key to dummy object\n");
+        return err;
+    }
+    err = test_load_dummy_object_field(cfg, obj, RIAK_TEST_VALUE_LEN, riak_object_set_value);
+    if (err) {
+        fprintf(stderr, "Could not add value to dummy object\n");
+        return err;
+    }
+    err = test_load_dummy_object_field(cfg, obj, 0, riak_object_set_charset);
+    if (err) {
+        fprintf(stderr, "Could not add charset to dummy object\n");
+        return err;
+    }
+    err = test_load_dummy_object_field(cfg, obj, 0, riak_object_set_content_type);
+    if (err) {
+        fprintf(stderr, "Could not add content-type to dummy object\n");
+        return err;
+    }
+    err = test_load_dummy_object_field(cfg, obj, 0, riak_object_set_content_encoding);
+    if (err) {
+        fprintf(stderr, "Could not add encoding to dummy object\n");
+        return err;
+    }
+    err = test_load_dummy_object_field(cfg, obj, 0, riak_object_set_vtag);
+    if (err) {
+        fprintf(stderr, "Could not add vtag to dummy object\n");
+        return err;
+    }
+    riak_object_set_last_mod(obj, test_random_int());
+    riak_object_set_last_mod_usecs(obj, test_random_int());
+
+    // Add some Links
+    for(int i = 0; i < 3; i++) {
+        riak_link *link = riak_object_new_link(cfg, obj);
+        if (link == NULL) {
+            return ERIAK_OUT_OF_MEMORY;
+        }
+        err = riak_link_set_bucket(cfg, link, bucket);
+        if (err) {
+            fprintf(stderr, "Could not add bucket to dummy link\n");
+            return err;
+        }
+        err = riak_link_set_key(cfg, link, key);
+        riak_binary *tag = test_random_binary(cfg, RIAK_TEST_BUCKET_KEY_LEN);
+        if (err) {
+            fprintf(stderr, "Could not add key to dummy link\n");
+            return err;
+        }
+        err = riak_link_set_tag(cfg, link, tag);
+        if (err) {
+            fprintf(stderr, "Could not add tag to dummy link\n");
+            return err;
+        }
+        riak_binary_free(cfg, &tag);
+    }
+
+    for(int i = 0; i < 3; i++) {
+        riak_pair *usermeta = riak_object_new_usermeta(cfg, obj);
+        if (usermeta == NULL) {
+            return ERIAK_OUT_OF_MEMORY;
+        }
+        err = riak_pair_set_key(cfg, usermeta, key);
+        if (err) {
+            fprintf(stderr, "Could not add key to dummy metadata\n");
+            return err;
+        }
+        err = riak_pair_set_value(cfg, usermeta, bucket);
+        if (err) {
+            fprintf(stderr, "Could not add value to dummy metadata\n");
+            return err;
+        }
+    }
+
+#if NEED_TO_SET_UP_2I_INDEXES_FIRST
+    for(int i = 0; i < 3; i++) {
+        riak_pair *index = riak_object_new_index(cfg, obj);
+        if (index == NULL) {
+            return ERIAK_OUT_OF_MEMORY;
+        }
+        err = riak_pair_set_key(cfg, index, bucket);
+        if (err) {
+            fprintf(stderr, "Could not add key to dummy index\n");
+            return err;
+        }
+        err = riak_pair_set_value(cfg, index, bucket);
+        if (err) {
+            fprintf(stderr, "Could not add value to dummy index\n");
+            return err;
+        }
+    }
+#endif
+
+    err = test_bkv_add(cfg, root, bucket, key, obj);
+    if (err) {
+        fprintf(stderr, "Could not add object to internal cache\n");
+        return err;
+    }
+    *obj_out = obj;
+    return ERIAK_OK;
+}
 
 riak_error
 test_load_db(riak_config            *cfg,
              riak_connection        *cxn,
-             test_bucket_key_value **root) {
-    fprintf(stderr, "Beginning load of Riak\n");
-    for (int b = 0; b < RIAK_TEST_MAX_BUCKETS; b++) {
+             test_bucket_key_value **root,
+             riak_uint32_t           n_buckets,
+             riak_uint32_t           n_keys) {
+    for (int b = 0; b < n_buckets; b++) {
         char *suffix = test_random_string(cfg, RIAK_TEST_BUCKET_KEY_LEN);
         if (suffix == NULL) {
             return ERIAK_OUT_OF_MEMORY;
         }
-        char bucket[128];
-        snprintf(bucket, sizeof(bucket), "%s%s", RIAK_TEST_BUCKET_PREFIX, suffix);
-        for(int k = 0; k < RIAK_TEST_MAX_KEYS; k++) {
-            char *key = test_random_string(cfg, RIAK_TEST_BUCKET_KEY_LEN);
+        char bucket_str[128];
+        snprintf(bucket_str, sizeof(bucket_str), "%s%s", RIAK_TEST_BUCKET_PREFIX, suffix);
+        riak_binary *bucket = riak_binary_copy_from_string(cfg, bucket_str);
+        if (bucket == NULL) {
+            return ERIAK_OUT_OF_MEMORY;
+        }
+        for(int k = 0; k < n_keys; k++) {
+            riak_binary *key = test_random_binary(cfg, RIAK_TEST_BUCKET_KEY_LEN);
             if (key == NULL) {
                 return ERIAK_OUT_OF_MEMORY;
             }
-            char *value = test_random_string(cfg, RIAK_TEST_VALUE_LEN);
+            riak_binary *value = test_random_binary(cfg, RIAK_TEST_VALUE_LEN);
             if (value == NULL) {
                 return ERIAK_OUT_OF_MEMORY;
             }
-            riak_object *obj = riak_object_new(cfg);
-            if (obj == NULL) {
-                return ERIAK_OUT_OF_MEMORY;
-            }
-            riak_binary *bucket_bin = riak_binary_copy_from_string(cfg, bucket);
-            if (bucket_bin == NULL) {
-                return ERIAK_OUT_OF_MEMORY;
-            }
-            riak_error err = riak_object_set_bucket(cfg, obj, bucket_bin);
-            if (err) {
-                return err;
-            }
-            riak_binary *key_bin = riak_binary_copy_from_string(cfg, key);
-            if (key_bin == NULL) {
-                return ERIAK_OUT_OF_MEMORY;
-            }
-            err = riak_object_set_key(cfg, obj, key_bin);
-            if (err) {
-                return err;
-            }
-            riak_binary *value_bin = riak_binary_copy_from_string(cfg, value);
-            if (value_bin == NULL) {
-                return ERIAK_OUT_OF_MEMORY;
-            }
-            err = riak_object_set_value(cfg, obj, value_bin);
-            if (err) {
-                return err;
-            }
+
             riak_put_response *response = NULL;
-            err = test_bkv_add(cfg, root, bucket_bin, key_bin, value_bin);
+            riak_object *obj;
+            riak_error err = test_load_dummy_object(cfg, bucket, key, &obj, root);
+            if (err) {
+                return err;
+            }
             err = riak_put(cxn, obj, NULL, &response);
             if (err) {
                 return err;
@@ -252,14 +397,14 @@ test_load_db(riak_config            *cfg,
             /*
              * These are now freed in test_bkv_free()
              *
-             * riak_binary_free(cfg, &bucket_bin);
-             * riak_binary_free(cfg, &key_bin);
-             * riak_binary_free(cfg, &value_bin);
+             * riak_binary_free(cfg, &bucket);
+             * riak_binary_free(cfg, &key);
+             * riak_binary_free(cfg, &value);
+             * riak_object_free(cfg, &obj);
              */
-            riak_object_free(cfg, &obj);
         }
+        riak_free(cfg, &suffix);
     }
-    fprintf(stderr, "Completed load of Riak\n");
     return ERIAK_OK;
 }
 
@@ -268,7 +413,6 @@ test_cleanup_db(riak_connection* cxn) {
     // Bail if there is no connection
     if (cxn == NULL) return ERIAK_CONNECT;
 
-    fprintf(stderr, "Beginning cleanup of Riak\n");
     const int prefixlen = strlen(RIAK_TEST_BUCKET_PREFIX);
     riak_listbuckets_response *response = NULL;
     riak_error err = riak_listbuckets(cxn, &response);
@@ -305,7 +449,6 @@ test_cleanup_db(riak_connection* cxn) {
             }
         }
     }
-    fprintf(stderr, "Completed cleanup of Riak\n");
     return ERIAK_OK;
 }
 

--- a/test/cunit/test_bucket_key_value.c
+++ b/test/cunit/test_bucket_key_value.c
@@ -25,22 +25,46 @@
 #include <stddef.h>
 #include <string.h>
 #include "test.h"
+#include "riak_utils-internal.h"
 
 riak_error
 test_bkv_add(riak_config            *cfg,
              test_bucket_key_value **root,
              riak_binary            *bucket,
              riak_binary            *key,
-             riak_binary            *value) {
-
-    test_bucket_key_value *node = riak_config_clean_allocate(cfg, sizeof(test_bucket_key_value));
+             riak_object            *obj) {
+    // Is this a sibling?
+    test_bucket_key_value *node = *root;
+    while (obj && node) {
+        // If this is a sibling, just add object (value will mismatch)
+        if (riak_binary_compare(node->bucket, bucket) == 0 &&
+            riak_binary_compare(node->key, key)) {
+            if (riak_array_realloc(cfg, (void***)&node->objs, sizeof(riak_object*), node->n_objs, node->n_objs+1) == NULL) {
+                return ERIAK_OUT_OF_MEMORY;
+            }
+            node->objs[node->n_objs++] = obj;
+            return ERIAK_OK;
+        }
+        node = node->next;
+    }
+    // If not a sibling, add a new node
+    node = riak_config_clean_allocate(cfg, sizeof(test_bucket_key_value));
     if (node == NULL) {
         return ERIAK_OUT_OF_MEMORY;
     }
-    node->next = *root;
+    node->next   = *root;
     node->bucket = bucket;
-    node->key = key;
-    node->value = value;
+    node->key    = key;
+    node->n_objs = 0;
+    node->objs   = riak_config_clean_allocate(cfg, sizeof(riak_object*));
+    if (node->objs == NULL) {
+        riak_free(cfg, &node);
+        return ERIAK_OUT_OF_MEMORY;
+    }
+    if (obj) {
+        node->objs[0] = obj;
+        node->n_objs++;
+    }
     *root = node;
 
     return ERIAK_OK;
@@ -53,7 +77,10 @@ test_bkv_free(riak_config *cfg,
     while (node != NULL) {
         riak_binary_free(cfg, &(node->bucket));
         riak_binary_free(cfg, &(node->key));
-        riak_binary_free(cfg, &(node->value));
+        for(int i = 0; i < node->n_objs; i++) {
+            riak_object_free(cfg, &(node->objs[i]));
+        }
+        riak_free(cfg, &node->objs);
         test_bucket_key_value *next = node->next;
         riak_free(cfg, &node);
         node = next;

--- a/test/cunit/test_bucket_key_value.c
+++ b/test/cunit/test_bucket_key_value.c
@@ -53,8 +53,8 @@ test_bkv_add(riak_config            *cfg,
         return ERIAK_OUT_OF_MEMORY;
     }
     node->next   = *root;
-    node->bucket = bucket;
-    node->key    = key;
+    node->bucket = riak_binary_copy(cfg, bucket);
+    node->key    = riak_binary_copy(cfg, key);
     node->n_objs = 0;
     node->objs   = riak_config_clean_allocate(cfg, sizeof(riak_object*));
     if (node->objs == NULL) {
@@ -71,7 +71,7 @@ test_bkv_add(riak_config            *cfg,
 }
 
 void
-test_bkv_free(riak_config *cfg,
+test_bkv_free(riak_config            *cfg,
               test_bucket_key_value **root) {
     test_bucket_key_value *node = *root;
     while (node != NULL) {

--- a/test/cunit/test_config.c
+++ b/test/cunit/test_config.c
@@ -69,6 +69,18 @@ test_log_logger(void            *ptr,
 }
 
 void
+test_stderr_logger(void            *ptr,
+                   riak_log_level_t level,
+                   const char      *file,
+                   riak_size_t      filelen,
+                   const char      *func,
+                   riak_size_t      funclen,
+                   riak_uint32_t    line,
+                   const char      *format,
+                   va_list          args) {
+}
+
+void
 test_config_with_logging() {
     riak_config *cfg;
     riak_error err = riak_config_new_default(&cfg);

--- a/test/cunit/test_get.c
+++ b/test/cunit/test_get.c
@@ -432,6 +432,7 @@ test_integration_async_get_value() {
     CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
 
     test_cleanup_db(cxn);
+    test_bkv_free(cfg, &db);
     test_disconnect(cfg, &cxn);
     test_cleanup(&cfg);
     CU_PASS("test_integration_async_get passed")
@@ -461,12 +462,16 @@ test_integration_async_get_bad_value() {
     riak_object *expected_obj = db->objs[0];
     riak_binary *bad = riak_binary_copy_from_string(cfg, "bad");
     CU_ASSERT_NOT_EQUAL_FATAL(bad,NULL)
+    riak_binary *cleanup = riak_object_get_value(expected_obj);
+    riak_binary_free(cfg, &cleanup);
     err = riak_object_set_value(cfg, expected_obj, bad);
     CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
     err = test_async_thread_runner(cfg, test_get_async_thread, (void*)&args, (void*)expected_obj);
     CU_ASSERT_EQUAL_FATAL(err,ERIAK_INVALID)
 
+    riak_binary_free(cfg, &bad);
     test_cleanup_db(cxn);
+    test_bkv_free(cfg, &db);
     test_disconnect(cfg, &cxn);
     test_cleanup(&cfg);
     CU_PASS("test_integration_async_bad_get passed")

--- a/test/cunit/test_get.c
+++ b/test/cunit/test_get.c
@@ -328,7 +328,7 @@ test_integration_get_value() {
     char output[10240];
     riak_print_state state;
     riak_print_init(&state, output, sizeof(output));
-    int result = riak_object_compare_debug(obj, expected_obj, RIAK_FALSE, &state);
+    int result = riak_object_compare_debug(obj, expected_obj, &state);
     riak_get_response_print(&state, response);
     //riak_object_print(&state, expected_obj);
     //riak_object_print(&state, obj);
@@ -370,7 +370,7 @@ test_get_async_cb(riak_get_response *response,
     }
     riak_object *obj = objs[0];
 
-    int result = riak_object_compare_debug(obj, expected, RIAK_FALSE, &print_state);
+    int result = riak_object_compare_debug(obj, expected, &print_state);
     if (result) {
         state->err = ERIAK_INVALID;
         snprintf(state->err_msg, sizeof(state->err_msg), "%s", output);
@@ -381,6 +381,7 @@ test_get_async_cb(riak_get_response *response,
     riak_get_response_print(&print_state, response);
     fprintf(stderr, "%s", output);
     riak_get_response_free(conn->cfg, &response);
+    state->err = ERIAK_OK;
 }
 
 typedef struct _test_async_pthread_get_args {

--- a/test/cunit/test_listbuckets.c
+++ b/test/cunit/test_listbuckets.c
@@ -128,6 +128,7 @@ test_listbuckets_async_cb(riak_listbuckets_response *response,
         snprintf(state->err_msg, sizeof(state->err_msg), "Only %ul keys were returned", num);
     }
     riak_listbuckets_response_free(conn->cfg, &response);
+    state->err = ERIAK_OK;
 }
 
 /**

--- a/test/cunit/test_listbuckets.c
+++ b/test/cunit/test_listbuckets.c
@@ -104,6 +104,7 @@ test_integration_listbuckets() {
 
     test_bkv_free(cfg, &db);
     test_cleanup_db(cxn);
+    test_bkv_free(cfg, &db);
     test_disconnect(cfg, &cxn);
     test_cleanup(&cfg);
     CU_PASS("test_integration_listbuckets passed")
@@ -164,6 +165,7 @@ test_integration_async_listbuckets() {
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
     test_cleanup_db(cxn);
+    test_bkv_free(cfg, &db);
     test_disconnect(cfg, &cxn);
     test_cleanup(&cfg);
     CU_PASS("test_integration_async_listbuckets passed")

--- a/test/cunit/test_listkeys.c
+++ b/test/cunit/test_listkeys.c
@@ -124,6 +124,7 @@ test_listkeys_async_cb(riak_listkeys_response *response,
         snprintf(state->err_msg, sizeof(state->err_msg), "Only %ul keys were returned", num);
     }
     riak_listkeys_response_free(conn->cfg, &response);
+    state->err = ERIAK_OK;
 }
 
 typedef struct _test_async_pthread_listkey_args {

--- a/test/cunit/test_listkeys.c
+++ b/test/cunit/test_listkeys.c
@@ -171,6 +171,7 @@ test_integration_async_listkeys() {
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
     test_cleanup_db(cxn);
+    test_bkv_free(cfg, &db);
     test_disconnect(cfg, &cxn);
     test_cleanup(&cfg);
     CU_PASS("test_integration_async_listkeys passed")

--- a/test/cunit/test_log.c
+++ b/test/cunit/test_log.c
@@ -1,0 +1,56 @@
+/*********************************************************************
+ *
+ * test_log.c:  Riak C Unit Testing logger
+ *
+ * Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+ *
+ * This file is provided to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *********************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <string.h>
+#include <time.h>
+#include "riak.h"
+
+void
+test_log(void            *ptr,
+         riak_log_level_t level,
+         const char      *file,
+         riak_size_t      filelen,
+         const char      *func,
+         riak_size_t      funclen,
+         riak_uint32_t    line,
+         const char      *format,
+         va_list          args) {
+    time_t ltime;
+    struct tm result;
+    char stime[32];
+    char output[2048];
+
+    ltime = time(NULL);
+    localtime_r(&ltime, &result);
+    strftime(stime, sizeof(stime), "%F %X %Z", &result);
+    riak_size_t wrote = snprintf(output, sizeof(output), "%s %s ", stime, riak_log_level_description(level));
+    char *pos = output + wrote;
+    wrote += vsnprintf(pos, sizeof(output)-wrote, format, args);
+    if (wrote < sizeof(output)-1) {
+        strcat(output, "\n");
+    }
+    // Just spew any output to stderr
+    fprintf(stderr, "%s", output);
+}

--- a/test/cunit/test_ping.c
+++ b/test/cunit/test_ping.c
@@ -59,7 +59,8 @@ test_integration_ping() {
 void
 test_ping_async_cb(riak_ping_response *response,
                    void               *ptr) {
-    test_async_connection *conn = (test_async_connection*)ptr;
+    test_async_pthread    *state = (test_async_pthread*)ptr;
+    test_async_connection *conn = (test_async_connection*)state->conn;
     riak_log_notice(conn->cxn, "%s", "Asynchronous PONG");
     riak_ping_response_free(conn->cfg, &response);
 }
@@ -89,7 +90,7 @@ test_integration_async_ping() {
     riak_error err = test_setup(&cfg);
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
-    err = test_async_thread_runner(cfg, test_ping_async_thread, NULL);
+    err = test_async_thread_runner(cfg, test_ping_async_thread, NULL, NULL);
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
     test_cleanup(&cfg);

--- a/test/cunit/test_ping.c
+++ b/test/cunit/test_ping.c
@@ -63,6 +63,7 @@ test_ping_async_cb(riak_ping_response *response,
     test_async_connection *conn = (test_async_connection*)state->conn;
     riak_log_notice(conn->cxn, "%s", "Asynchronous PONG");
     riak_ping_response_free(conn->cfg, &response);
+    state->err = ERIAK_OK;
 }
 
 /**

--- a/test/cunit/test_serverinfo.c
+++ b/test/cunit/test_serverinfo.c
@@ -155,7 +155,8 @@ test_integration_server_info() {
 void
 test_serverinfo_async_cb(riak_serverinfo_response *response,
                          void                     *ptr) {
-    test_async_connection *conn = (test_async_connection*)ptr;
+    test_async_pthread    *state = (test_async_pthread*)ptr;
+    test_async_connection *conn = (test_async_connection*)state->conn;
     char output[1024];
     riak_print_state print_state;
     riak_print_init(&print_state, output, sizeof(output));
@@ -188,7 +189,7 @@ test_integration_async_server_info() {
     riak_error err = test_setup(&cfg);
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
-    err = test_async_thread_runner(cfg, test_serverinfo_async_thread, NULL);
+    err = test_async_thread_runner(cfg, test_serverinfo_async_thread, NULL, NULL);
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
     test_cleanup(&cfg);

--- a/test/cunit/test_serverinfo.c
+++ b/test/cunit/test_serverinfo.c
@@ -163,6 +163,7 @@ test_serverinfo_async_cb(riak_serverinfo_response *response,
     riak_serverinfo_response_print(&print_state, response);
     fprintf(stderr, "ASYNCHRONOUS %s", output);
     riak_serverinfo_response_free(conn->cfg, &response);
+    state->err = ERIAK_OK;
 }
 
 /**


### PR DESCRIPTION
- Make unit testing write more complete test objects
- Make the number of buckets/keys in dummy object configurable to optimize testing time
- Add several helper functions like comparing binaries and objects
- Improve error reporting in testing async callbacks
- Clean up all outstanding memory leaks in current integration tests (but not unit tests)
