### PR TITLE
Add Integration Tests for Get/Set Client ID

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -143,8 +143,6 @@ riak_c_async_example_LDADD = \
 	$(PROTOBUF_LIBS) \
 	$(EVENT_LIBS)
 
-riak_c_async_example_DEPENDENCIES = libriak_c_client-0.5.la
-
 check_PROGRAMS = riak_c_cunit
 riak_c_cunit_SOURCES = test/cunit/test.c \
 			test/cunit/registry.c \
@@ -191,4 +189,12 @@ TESTS = riak_c_cunit
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = riak-c-client-async.pc \
 			riak-c-client.pc
+
+integration-tests: $(check_PROGRAMS)
+	./riak_c_cunit --integration
+
+valgrind-tests: $(check_PROGRAMS)
+	$(LIBTOOL) --mode=execute valgrind --leak-check=full --show-leak-kinds=all ./riak_c_cunit
+
+.PHONY: integration-tests valgrind-tests
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -196,5 +196,8 @@ integration-tests: $(check_PROGRAMS)
 valgrind-tests: $(check_PROGRAMS)
 	$(LIBTOOL) --mode=execute valgrind --leak-check=full --show-leak-kinds=all ./riak_c_cunit
 
+valgrind-integration-tests: $(check_PROGRAMS)
+	$(LIBTOOL) --mode=execute valgrind --leak-check=full --show-leak-kinds=all ./riak_c_cunit --integration
+
 .PHONY: integration-tests valgrind-tests
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -196,5 +196,11 @@ integration-tests: $(check_PROGRAMS)
 valgrind-tests: $(check_PROGRAMS)
 	$(LIBTOOL) --mode=execute valgrind --leak-check=full --show-leak-kinds=all ./riak_c_cunit
 
-.PHONY: integration-tests valgrind-tests
+gdb-tests: $(check_PROGRAMS)
+	$(LIBTOOL) --mode=execute gdb ./riak_c_cunit
+
+lldb-tests: $(check_PROGRAMS)
+	$(LIBTOOL) --mode=execute lldb ./riak_c_cunit
+
+.PHONY: integration-tests valgrind-tests gdb-tests lldb-tests
 

--- a/examples/example.c
+++ b/examples/example.c
@@ -95,7 +95,6 @@ main(int   argc,
     riak_reset_bucketprops_response *reset_response = NULL;
     riak_search_response            *search_response = NULL;
     riak_serverinfo_response        *serverinfo_response = NULL;
-    riak_set_clientid_response      *setcli_response = NULL;
 
     // iterate through argv
     for(it = 0; it < args.iterate; it++) {
@@ -239,8 +238,7 @@ main(int   argc,
             }
             break;
         case RIAK_COMMAND_SETCLIENTID:
-            err = riak_set_clientid(cxn, value_bin, &setcli_response);
-            riak_set_clientid_response_free(cfg, &setcli_response);
+            err = riak_set_clientid(cxn, value_bin);
             if (err) {
                 fprintf(stderr, "Set ClientID Problems [%s]\n", riak_strerror(err));
                 exit(1);

--- a/src/include/riak.h
+++ b/src/include/riak.h
@@ -154,13 +154,11 @@ riak_get_clientid(riak_connection             *cxn,
  * @brief Synchronous fetching of client ID request
  * @param cxn Riak Connection
  * @param clientid Name of client id for current connection
- * @param response Returned Fetched data
  * @returns Error code
  */
 riak_error
 riak_set_clientid(riak_connection             *cxn,
-                  riak_binary                 *clientid,
-                  riak_set_clientid_response **response);
+                  riak_binary                 *clientid);
 
 /**
  * @brief List the properties associated with a bucket

--- a/src/riak.c
+++ b/src/riak.c
@@ -254,9 +254,8 @@ riak_get_clientid(riak_connection             *cxn,
 }
 
 riak_error
-riak_set_clientid(riak_connection             *cxn,
-                  riak_binary                 *clientid,
-                  riak_set_clientid_response **response) {
+riak_set_clientid(riak_connection *cxn,
+                  riak_binary     *clientid) {
     riak_operation *rop = NULL;
     riak_error err = riak_operation_new(cxn, &rop, NULL, NULL, NULL);
     if (err) {
@@ -266,7 +265,8 @@ riak_set_clientid(riak_connection             *cxn,
     if (err) {
         return err;
     }
-    err = riak_sync_request(&rop, (void**)response);
+    riak_set_clientid_response *response = NULL;
+    err = riak_sync_request(&rop, (void**)&response);
     if (err) {
         return err;
     }

--- a/test/cunit/include/test_clientid.h
+++ b/test/cunit/include/test_clientid.h
@@ -25,3 +25,9 @@ test_set_clientid();
 
 void
 test_get_clientid();
+
+void
+test_integration_clientid();
+
+void
+test_integration_async_clientid();

--- a/test/cunit/registry.c
+++ b/test/cunit/registry.c
@@ -185,6 +185,8 @@ main(int   argc,
     CU_ADD_TEST(integration_suite, test_integration_async_get_bad_value);
     CU_ADD_TEST(integration_suite, test_integration_delete);
     CU_ADD_TEST(integration_suite, test_integration_async_delete);
+    CU_ADD_TEST(integration_suite, test_integration_clientid);
+    CU_ADD_TEST(integration_suite, test_integration_async_clientid);
 
     // Only run integration tests if an argument is passed in
     if (argc < 2) {

--- a/test/cunit/test_clientid.c
+++ b/test/cunit/test_clientid.c
@@ -30,7 +30,11 @@
 #include "riak.h"
 #include "riak_messages-internal.h"
 #include "riak_operation-internal.h"
+#include "test.h"
 
+/**
+ * @brief Test decoding a fixed response from a set clientid request
+ */
 void
 test_set_clientid() {
     riak_config     *cfg;
@@ -48,6 +52,7 @@ test_set_clientid() {
     clientid.data = (riak_uint8_t*)"test_clientid";
     clientid.len = sizeof("test_clientid");
 
+    // Binary Protocol Buffer message from server
     riak_uint8_t bytes[] = { 0x0a,0x0e,0x74,0x65,0x73,0x74,0x5f,0x63,0x6c,0x69,0x65,0x6e,0x74,0x69,0x64,0x00 };
     err = riak_set_clientid_request_encode(rop, &clientid, &request);
     CU_ASSERT_FATAL(err == ERIAK_OK)
@@ -60,6 +65,9 @@ test_set_clientid() {
     CU_PASS("test_set_clientid passed")
 }
 
+/**
+ * @brief Test decoding a fixed response from a get clientid request
+ */
 void
 test_get_clientid() {
     riak_config     *cfg;
@@ -73,6 +81,7 @@ test_get_clientid() {
     CU_ASSERT_FATAL(err == ERIAK_CONNECT)
     err = riak_operation_new(cxn, &rop, NULL, NULL, NULL);
 
+    // Binary Protocol Buffer message from server
     riak_uint8_t bytes[] = { 0x04,0x0a,0x04,0x00,0x00,0x00,0x00 };
     riak_pb_message pb_resp;
     pb_resp.data = bytes;
@@ -90,3 +99,137 @@ test_get_clientid() {
     riak_config_free(&cfg);
     CU_PASS("test_server_info_encode_request passed")
 }
+
+
+void
+test_integration_clientid() {
+    riak_config     *cfg;
+    riak_connection *cxn = NULL;
+
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    err = test_connect(cfg, &cxn);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    riak_binary *client_id = test_random_binary(cfg, RIAK_TEST_BUCKET_KEY_LEN);
+    CU_ASSERT_NOT_EQUAL_FATAL(client_id,NULL)
+    err = riak_set_clientid(cxn, client_id);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+    riak_get_clientid_response *response = NULL;
+    err = riak_get_clientid(cxn, &response);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+    int equals = riak_binary_compare(client_id, riak_get_clientid_get_clientid(response));
+    CU_ASSERT_EQUAL_FATAL(equals,0)
+    riak_get_clientid_response_free(cfg, &response);
+
+    test_disconnect(cfg, &cxn);
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_clientid passed")
+}
+
+typedef struct _test_async_pthread_clientid_args {
+    riak_binary *clientid;
+} test_async_pthread_clientid_args;
+
+void
+test_set_clientid_async_cb(riak_set_clientid_response *response,
+                           void                       *ptr) {
+    test_async_pthread              *state = (test_async_pthread*)ptr;
+    test_async_connection            *conn = (test_async_connection*)state->conn;
+
+    riak_set_clientid_response_free(conn->cfg, &response);
+    state->err = ERIAK_OK;
+}
+
+void
+test_get_clientid_async_cb(riak_get_clientid_response *response,
+                           void                       *ptr) {
+    test_async_pthread     *state    = (test_async_pthread*)ptr;
+    test_async_connection  *conn     = (test_async_connection*)state->conn;
+    riak_binary            *clientid = (riak_binary*)state->expected;
+    riak_binary            *result   = riak_get_clientid_get_clientid(response);
+    int                     equals   = riak_binary_compare(clientid, result);
+    if (!equals) {
+        state->err = ERIAK_INVALID;
+        riak_print_state print_state;
+        riak_print_init(&print_state, state->err_msg, sizeof(state->err_msg));
+        riak_print(&print_state, "%s", "Expected Client ID of '");
+        riak_print_binary(&print_state, clientid);
+        riak_print(&print_state, "%s", "' but received '");
+        riak_print_binary(&print_state, result);
+        riak_print(&print_state, "%s", "'\n");
+
+        riak_get_clientid_response_free(conn->cfg, &response);
+        return;
+    }
+
+    riak_get_clientid_response_free(conn->cfg, &response);
+    state->err = ERIAK_OK;
+}
+
+/**
+ * @brief Encode and Send a Set Client ID request
+ * @param args Parameters required to create set clientid request
+ */
+void*
+test_set_clientid_async_thread(void *ptr) {
+    test_async_pthread    *state = (test_async_pthread*)ptr;
+    test_async_connection *conn  = state->conn;
+    test_async_pthread_clientid_args *args = (test_async_pthread_clientid_args*)(state->args);
+    riak_error err = riak_async_register_set_clientid(conn->rop, args->clientid, (riak_response_callback)test_set_clientid_async_cb);
+    if (err) {
+        return (void*)riak_strerror(err);
+    }
+    err = test_async_send_message(conn);
+    if (err) {
+        return (void*)"Could not send request";
+    }
+    return NULL;
+}
+
+/**
+ * @brief Encode and Send a Get Client ID request
+ * @param args Parameters required to create set clientid request
+ */
+void*
+test_get_clientid_async_thread(void *ptr) {
+    test_async_pthread    *state = (test_async_pthread*)ptr;
+    test_async_connection *conn  = state->conn;
+    riak_error err = riak_async_register_get_clientid(conn->rop, (riak_response_callback)test_get_clientid_async_cb);
+    if (err) {
+        return (void*)riak_strerror(err);
+    }
+    err = test_async_send_message(conn);
+    if (err) {
+        return (void*)"Could not send request";
+    }
+    return NULL;
+}
+
+void
+test_integration_async_clientid() {
+    riak_config           *cfg;
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    riak_connection *cxn = NULL;
+    err = test_connect(cfg, &cxn);
+    CU_ASSERT_FATAL(err == ERIAK_OK)
+
+    test_async_pthread_clientid_args args;
+    riak_binary *client_id = test_random_binary(cfg, RIAK_TEST_BUCKET_KEY_LEN);
+    CU_ASSERT_NOT_EQUAL_FATAL(client_id,NULL)
+    args.clientid = client_id;  // Random String
+
+    err = test_async_thread_runner(cfg, test_set_clientid_async_thread, (void*)&args, NULL);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+
+    err = test_async_thread_runner(cfg, test_get_clientid_async_thread, (void*)&args, (void*)client_id);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+
+    test_disconnect(cfg, &cxn);
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_async_clientid passed")
+}
+


### PR DESCRIPTION
- Also remove useless response to set client Id
- Add and new make targets: `integration-tests`, `valgrind-tests`, `gdb-tests` and `lldb-tests`
