### PR TITLE
Add Integration Tests for Map/Reduce

### DIFF
--- a/src/include/messages/riak_mapreduce.h
+++ b/src/include/messages/riak_mapreduce.h
@@ -51,6 +51,14 @@ riak_mapreduce_response_print(riak_print_state        *state,
                               riak_mapreduce_response *response);
 
 /**
+ * @brief Determine the number of messages returned in the response
+ * @prarm response The Map/Reduce response
+ * @returns Number of messages included in the response
+ */
+riak_int32_t
+riak_mapreduce_get_n_messages(riak_mapreduce_response *response);
+
+/**
  * @brief Access the array of received map/reduce messages
  * @param response Riak Map/Reduce response
  * @returns Array of pointers to map/reduce messages

--- a/src/messages/riak_mapreduce.c
+++ b/src/messages/riak_mapreduce.c
@@ -172,6 +172,7 @@ riak_mapreduce_response_free(riak_config              *cfg,
         riak_free(cfg, &(response->msg[i]));
         rpb_map_red_resp__free_unpacked(response->_internal[i], cfg->pb_allocator);
     }
+    riak_free(cfg, &(response->msg));
     riak_free(cfg, &(response->_internal));
     riak_free(cfg, resp);
 }

--- a/src/messages/riak_mapreduce.c
+++ b/src/messages/riak_mapreduce.c
@@ -176,6 +176,11 @@ riak_mapreduce_response_free(riak_config              *cfg,
     riak_free(cfg, resp);
 }
 
+riak_int32_t
+riak_mapreduce_get_n_messages(riak_mapreduce_response *response) {
+    return response->n_responses;
+}
+
 riak_mapreduce_message**
 riak_mapreduce_get_messages(riak_mapreduce_response *response) {
     return response->msg;

--- a/test/cunit/include/test.h
+++ b/test/cunit/include/test.h
@@ -157,6 +157,17 @@ test_random_string(riak_config  *cfg,
 riak_binary*
 test_random_binary(riak_config  *cfg,
                    riak_uint32_t len);
+/**
+ * @brief Build a random printable riak_binary with a specific prefix
+ * @param cfg Riak Configuration
+ * @param prefix Constant string prepended to resulting string
+ * @param len Length of generated string
+ * @returns Random riak_binary
+ */
+riak_binary*
+test_random_binary_with_prefix(riak_config  *cfg,
+                               const char   *prefix,
+                               riak_uint32_t len);
 
 /**
  * @brief Generate a random integer

--- a/test/cunit/include/test_mapreduce.h
+++ b/test/cunit/include/test_mapreduce.h
@@ -22,3 +22,9 @@
 
 void
 test_mapreduce_response_decode();
+
+void
+test_integration_mapreduce();
+
+void
+test_integration_async_mapreduce();

--- a/test/cunit/registry.c
+++ b/test/cunit/registry.c
@@ -190,6 +190,8 @@ main(int   argc,
     CU_ADD_TEST(integration_suite, test_integration_async_clientid);
     CU_ADD_TEST(integration_suite, test_integration_error);
     CU_ADD_TEST(integration_suite, test_integration_async_error);
+    CU_ADD_TEST(integration_suite, test_integration_mapreduce);
+    CU_ADD_TEST(integration_suite, test_integration_async_mapreduce);
 
     // Only run integration tests if an argument is passed in
     if (argc < 2) {

--- a/test/cunit/test_mapreduce.c
+++ b/test/cunit/test_mapreduce.c
@@ -302,7 +302,7 @@ test_integration_async_mapreduce() {
     test_async_pthread_mapreduce_args args;
     args.content   = content;
     args.query     = query;
-    args.streaming = RIAK_TRUE;
+    args.streaming = RIAK_FALSE;
     err = test_async_thread_runner(cfg, test_mapreduce_async_thread, (void*)&args, (void*)NULL);
     CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
 

--- a/test/cunit/test_mapreduce.c
+++ b/test/cunit/test_mapreduce.c
@@ -30,7 +30,11 @@
 #include "riak.h"
 #include "riak_messages-internal.h"
 #include "riak_operation-internal.h"
+#include "test.h"
 
+/**
+ * @brief Test the Map/Reduce message decoder with a fixed message response
+ */
 void
 test_mapreduce_response_decode() {
     riak_config     *cfg;
@@ -45,6 +49,7 @@ test_mapreduce_response_decode() {
     err = riak_operation_new(cxn, &rop, NULL, NULL, NULL);
     CU_ASSERT_FATAL(err == ERIAK_OK)
 
+    // Static response from Riak server
     riak_uint8_t bytes0[] = { 0x18,0x08,0x00,0x12,0x0b,0x5b,0x5b,0x22,0x66,0x6f,0x6f,0x22,0x2c,0x31,0x5d,0x5d };
     riak_uint8_t bytes1[] = { 0x18,0x08,0x00,0x12,0x0b,0x5b,0x5b,0x22,0x62,0x61,0x6d,0x22,0x2c,0x33,0x5d,0x5d };
     riak_uint8_t bytes2[] = { 0x18,0x08,0x00,0x12,0x0b,0x5b,0x5b,0x22,0x62,0x61,0x7a,0x22,0x2c,0x30,0x5d,0x5d };
@@ -75,3 +80,237 @@ test_mapreduce_response_decode() {
     CU_ASSERT_EQUAL_FATAL(riak_mapreduce_message_get_has_done(msgs[4]), RIAK_TRUE)
     CU_ASSERT_EQUAL_FATAL(riak_mapreduce_message_get_done(msgs[4]), RIAK_TRUE)
 }
+
+typedef struct _test_load_mr_data {
+    const char *key;
+    const char *value;
+} test_load_mr_data;
+
+/**
+ * @brief Load a pile of data for an M/R operation
+ * @param cxn Riak Connection
+ * @param query_string Returned M/R query Javascript function
+ */
+riak_error
+test_setup_mr_test(riak_connection *cxn,
+                   riak_binary    **query) {
+    riak_config *cfg = riak_connection_get_config(cxn);
+    riak_binary *bucket = test_random_binary_with_prefix(cfg, RIAK_TEST_BUCKET_PREFIX, RIAK_TEST_BUCKET_KEY_LEN);
+    riak_binary *content = riak_binary_copy_from_string(cfg, "text/plain");
+    if (bucket == NULL || content == NULL) {
+        return ERIAK_OUT_OF_MEMORY;
+    }
+    test_load_mr_data data[] = {
+            { "foo", "pizza data goes here" },
+            { "bar", "pizza pizza pizza pizza" },
+            { "baz", "nothing to see here" },
+            { "bam", "pizza pizza pizza" }
+    };
+    for(int i = 0; i < sizeof(data)/sizeof(test_load_mr_data); i++) {
+        riak_object *obj = riak_object_new(cfg);
+        if (obj == NULL) {
+            return ERIAK_OUT_OF_MEMORY;
+        }
+        riak_error err = riak_object_set_bucket(cfg, obj, bucket);
+        if (err) {
+            return err;
+        }
+        riak_binary *key = riak_binary_copy_from_string(cfg, data[i].key);
+        if (key == NULL) {
+            return ERIAK_OUT_OF_MEMORY;
+        }
+        riak_binary *value = riak_binary_copy_from_string(cfg, data[i].value);
+        if (value == NULL) {
+            return ERIAK_OUT_OF_MEMORY;
+        }
+        err = riak_object_set_key(cfg, obj, key);
+        if (err) {
+            return err;
+        }
+        err = riak_object_set_value(cfg, obj, value);
+        if (err) {
+            return err;
+        }
+        err = riak_object_set_content_encoding(cfg, obj, content);
+        if (err) {
+            return err;
+        }
+        riak_put_response *response;
+        err = riak_put(cxn, obj, NULL, &response);
+        if (err) {
+            return err;
+        }
+        riak_binary_free(cfg, &key);
+        riak_binary_free(cfg, &value);
+        riak_object_free(cfg, &obj);
+        riak_put_response_free(cfg, &response);
+    }
+
+    riak_binary_free(cfg, &content);
+
+    char query_buffer[1024];
+    riak_print_state query_state;
+    riak_print_init(&query_state, query_buffer, sizeof(query_buffer));
+    riak_print(&query_state, "%s", "{\"inputs\":\"");
+    riak_print_binary(&query_state, bucket);
+    riak_print(&query_state, "%s", "\","
+        "\"query\":[{\"map\":{\"language\":\"javascript\","
+        "\"source\":\"function(riakObject) {"
+        "    var val = riakObject.values[0].data.match(/pizza/g);"
+        "    return [[riakObject.key, (val ? val.length : 0 )]];"
+        "}\"}}]}");
+    *query = riak_binary_copy_from_string(cfg, query_buffer);
+    riak_binary_free(cfg, &bucket);
+
+    return ERIAK_OK;
+}
+
+riak_boolean_t
+test_mapreduce_compare(riak_mapreduce_response *response) {
+    riak_uint32_t num = riak_mapreduce_get_n_messages(response);
+    CU_ASSERT_EQUAL_FATAL(num,5)
+    riak_mapreduce_message **messages = riak_mapreduce_get_messages(response);
+    CU_ASSERT_NOT_EQUAL_FATAL(messages,NULL)
+
+    const char* results[] = {
+        "[[\"bam\",3]]",
+        "[[\"baz\",0]]",
+        "[[\"bar\",4]]",
+        "[[\"foo\",1]]"
+    };
+    // Go through all results and make sure they come back (in any order)
+    for(int i = 0; i < sizeof(results)/sizeof(char*); i++) {
+        int j = 0;
+        for(j = 0; j < num; j++) {
+            riak_binary *result = riak_mapreduce_message_get_response(messages[i]);
+            if (result == NULL) {
+                return RIAK_FALSE;
+            }
+            if (riak_binary_compare_string(result, results[j]) == 0 &&
+                riak_mapreduce_message_get_phase(messages[i]) == 0) {
+                break;
+            }
+        }
+        if (j >= num) {
+            return RIAK_FALSE;
+        }
+    }
+
+    return RIAK_TRUE;
+}
+
+void
+test_integration_mapreduce() {
+    riak_config     *cfg;
+    riak_connection *cxn = NULL;
+
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+
+    err = test_connect(cfg, &cxn);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+
+    riak_binary *query;
+    err = test_setup_mr_test(cxn, &query);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+    CU_ASSERT_NOT_EQUAL_FATAL(query,NULL)
+    riak_binary *content = riak_binary_copy_from_string(cfg, "application/json");
+    CU_ASSERT_NOT_EQUAL_FATAL(content,NULL)
+
+    riak_mapreduce_response *response = NULL;
+    err = riak_mapreduce(cxn, content, query, &response);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+
+    char output[10240];
+    riak_print_state state;
+    riak_print_init(&state, output, sizeof(output));
+    riak_mapreduce_response_print(&state, response);
+    fprintf(stderr, "%s", output);
+    CU_ASSERT_EQUAL_FATAL(test_mapreduce_compare(response),RIAK_TRUE)
+    riak_mapreduce_response_free(cfg, &response);
+
+    riak_binary_free(cfg, &content);
+    riak_binary_free(cfg, &query);
+    test_cleanup_db(cxn);
+    test_disconnect(cfg, &cxn);
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_mapreduce_value passed")
+}
+
+void
+test_mapreduce_async_cb(riak_mapreduce_response *response,
+                  void              *ptr) {
+    test_async_pthread    *state = (test_async_pthread*)ptr;
+    test_async_connection *conn = (test_async_connection*)state->conn;
+
+    char output[10240];
+    riak_print_state print_state;
+    riak_print_init(&print_state, output, sizeof(output));
+
+    //riak_object_print(&state, expected);
+    riak_mapreduce_response_print(&print_state, response);
+    fprintf(stderr, "%s", output);
+    riak_boolean_t match = test_mapreduce_compare(response);
+    riak_mapreduce_response_free(conn->cfg, &response);
+    state->err = (match) ? ERIAK_OK : ERIAK_INVALID;
+}
+
+typedef struct _test_async_pthread_mapreduce_args {
+    riak_binary   *content;
+    riak_binary   *query;
+    riak_boolean_t streaming;
+} test_async_pthread_mapreduce_args;
+
+/**
+ * @brief Encode and Send a Get request
+ * @param args Parameters required to create Get request
+ */
+void*
+test_mapreduce_async_thread(void *ptr) {
+    test_async_pthread    *state = (test_async_pthread*)ptr;
+    test_async_connection *conn  = state->conn;
+    test_async_pthread_mapreduce_args *args = (test_async_pthread_mapreduce_args*)(state->args);
+    riak_error err = riak_async_register_mapreduce(conn->rop, args->content, args->query, args->streaming, (riak_response_callback)test_mapreduce_async_cb);
+    if (err) {
+        return (void*)riak_strerror(err);
+    }
+    err = test_async_send_message(conn);
+    if (err) {
+        return (void*)"Could not send request";
+    }
+    return NULL;
+}
+
+void
+test_integration_async_mapreduce() {
+    riak_config     *cfg;
+    riak_connection *cxn = NULL;
+
+    riak_error err = test_setup(&cfg);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+
+    err = test_connect(cfg, &cxn);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+
+    riak_binary *query;
+    err = test_setup_mr_test(cxn, &query);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+    CU_ASSERT_NOT_EQUAL_FATAL(query,NULL)
+    riak_binary *content = riak_binary_copy_from_string(cfg, "application/json");
+    CU_ASSERT_NOT_EQUAL_FATAL(content,NULL)
+
+    test_async_pthread_mapreduce_args args;
+    args.content   = content;
+    args.query     = query;
+    args.streaming = RIAK_TRUE;
+    err = test_async_thread_runner(cfg, test_mapreduce_async_thread, (void*)&args, (void*)NULL);
+    CU_ASSERT_EQUAL_FATAL(err,ERIAK_OK)
+
+    riak_binary_free(cfg, &content);
+    riak_binary_free(cfg, &query);
+    test_cleanup_db(cxn);
+    test_disconnect(cfg, &cxn);
+    test_cleanup(&cfg);
+    CU_PASS("test_integration_async_mapreduce passed")
+}
+


### PR DESCRIPTION
- Tweak a few test generators to restrict test strings to [0-9A-Za-z] to make Javascript happy
- Add some missing interfaces
- Clean up a memory leak
